### PR TITLE
fix(ui): prevent 404 - NotFound errors on refresh

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 !.idea/
 .idea/*
 !.idea/runConfigurations/
+
+# Vercel
+.vercel

--- a/ui/netlify.toml
+++ b/ui/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+  force = true

--- a/ui/vercel.json
+++ b/ui/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/"
+    }
+  ]
+}


### PR DESCRIPTION
Since the example UI is a single page application with client side routing, manually typing a URL other than the root `/` index route results in a 404 error. Same with refreshing the page.

This adds configuration settings for Vercel and Netlify that rewrites HTTP requests on the server to index.html, where the router lives, so it can load and display the requested route.