### PR TITLE
fix(ui): Update 'max stake' allowed per validator calculation

### DIFF
--- a/ui/src/api/queries.ts
+++ b/ui/src/api/queries.ts
@@ -41,7 +41,7 @@ export const mbrQueryOptions = queryOptions({
 export const constraintsQueryOptions = queryOptions({
   queryKey: ['constraints'],
   queryFn: () => fetchProtocolConstraints(),
-  staleTime: Infinity,
+  staleTime: 1000 * 60 * 30, // every 30 mins
 })
 
 export const balanceQueryOptions = (address: string | null) =>

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -116,7 +116,7 @@ export function ValidatorTable({ validators, stakesByValidator }: ValidatorTable
           notation: 'compact',
         }).format(currentStake)
 
-        const maxStake = calculateMaxStake(validator, true)
+        const maxStake = calculateMaxStake(validator, constraints!, true)
         const maxStakeCompact = new Intl.NumberFormat(undefined, {
           notation: 'compact',
         }).format(maxStake)

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -378,9 +378,20 @@ export function getAddValidatorFormSchema(constraints: Constraints) {
     })
 }
 
-export function calculateMaxStake(validator: Validator, algos = false): number {
+export function calculateMaxStake(
+  validator: Validator,
+  constraints: Constraints,
+  algos = false,
+): number {
   const { numPools } = validator.state
-  const { maxAlgoPerPool } = validator.config
+  const hardMaxDividedBetweenPools = constraints.maxAlgoPerValidator / BigInt(numPools)
+  let { maxAlgoPerPool } = validator.config
+  if (maxAlgoPerPool === 0n) {
+    maxAlgoPerPool = constraints.maxAlgoPerPool
+  }
+  if (hardMaxDividedBetweenPools < maxAlgoPerPool) {
+    maxAlgoPerPool = hardMaxDividedBetweenPools
+  }
 
   const maxStake = Number(maxAlgoPerPool) * numPools
 


### PR DESCRIPTION
Enhanced the max stake per-pool calculation function to use the 'protocol constraints' and taking lesser of (max per validator / num pools) or protocol max per pool.  The constraints will also be updated at least once every 30 minutes.