### PR TITLE
ci(ui): add conditions for running CI workflow for UI

### DIFF
--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -5,13 +5,13 @@ on:
     branches: [ dev, main ]
     paths:
       - 'ui/**'
-      - '.github/workflows/ci-ui.yaml'
+      # - '.github/workflows/ci-ui.yaml'
 
   pull_request:
     branches: [ dev, main ]
     paths:
       - 'ui/**'
-      - '.github/workflows/ci-ui.yaml'
+      # - '.github/workflows/ci-ui.yaml'
 
 jobs:
   run-ci:

--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -3,11 +3,19 @@ name: CI Workflow (UI)
 on:
   push:
     branches: [ dev, main ]
+    paths:
+      - 'ui/**'
+      - '.github/workflows/ci-ui.yaml'
+
   pull_request:
     branches: [ dev, main ]
+    paths:
+      - 'ui/**'
+      - '.github/workflows/ci-ui.yaml'
 
 jobs:
   run-ci:
+    if: "!contains(github.event.head_commit.message, 'chore: release v')"
     name: Lint, Typecheck, Test, and Build
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
The UI's CI workflow will only run when there are changes to files in the `ui` folder. An additional check prevents the workflow from running a second time for `chore: release vX.X.X` commits to the `dev` branch.