### PR TITLE
feat(ui): improved nfdForInfo display in ValidatorTable

### DIFF
--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -2,6 +2,7 @@ import * as algokit from '@algorandfoundation/algokit-utils'
 import { TransactionSignerAccount } from '@algorandfoundation/algokit-utils/types/account'
 import { AlgoAmount } from '@algorandfoundation/algokit-utils/types/amount'
 import algosdk from 'algosdk'
+import { fetchNfd } from '@/api/nfd'
 import { StakingPoolClient } from '@/contracts/StakingPoolClient'
 import { ValidatorRegistryClient } from '@/contracts/ValidatorRegistryClient'
 import { StakedInfo, StakerPoolData, StakerValidatorData } from '@/interfaces/staking'
@@ -159,6 +160,12 @@ export async function fetchValidator(
       rawPoolTokenPayoutRatios,
       rawNodePoolAssignment,
     )
+
+    if (validator.config.nfdForInfo > 0) {
+      const nfd = await fetchNfd(validator.config.nfdForInfo)
+      validator.nfd = nfd
+    }
+
     return validator
   } catch (error) {
     console.error(error)

--- a/ui/src/components/NfdAvatar.tsx
+++ b/ui/src/components/NfdAvatar.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react'
 import { Avatar, AvatarImage } from '@/components/ui/avatar'
 import { Nfd } from '@/interfaces/nfd'
 import { getNfdAvatarUrl } from '@/utils/nfd'
@@ -7,10 +8,12 @@ interface NfdAvatarProps {
   className?: string
 }
 
-export function NfdAvatar({ nfd, className = '' }: NfdAvatarProps) {
+const NfdAvatar: React.FC<NfdAvatarProps> = React.memo(function NfdAvatar({ nfd, className = '' }) {
   return (
     <Avatar className={className}>
       <AvatarImage src={getNfdAvatarUrl(nfd)} alt={nfd.name} />
     </Avatar>
   )
-}
+})
+
+export { NfdAvatar }

--- a/ui/src/components/NfdThumbnail.tsx
+++ b/ui/src/components/NfdThumbnail.tsx
@@ -1,42 +1,103 @@
 import { useQuery } from '@tanstack/react-query'
+import * as React from 'react'
 import { nfdQueryOptions } from '@/api/queries'
-import { getNfdProfileUrl } from '@/utils/nfd'
 import { NfdAvatar } from '@/components/NfdAvatar'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Nfd } from '@/interfaces/nfd'
+import { getNfdProfileUrl } from '@/utils/nfd'
+import { cn } from '@/utils/ui'
 
-export interface NfdThumbnailProps {
-  nameOrId: string | number
+type NfdThumbnailProps = (
+  | {
+      nfd: Nfd
+      nameOrId?: never
+    }
+  | {
+      nfd?: never
+      nameOrId: string | number
+    }
+) & {
   link?: boolean
+  truncate?: boolean
+  tooltip?: boolean
+  className?: string
 }
 
-export function NfdThumbnail({ nameOrId, link = false }: NfdThumbnailProps) {
-  const { data: nfd, isLoading, error } = useQuery(nfdQueryOptions(nameOrId))
+function NfdThumbnailBase({
+  nfd: nfdProp,
+  nameOrId,
+  link = false,
+  truncate = false,
+  tooltip = false,
+  className = '',
+}: NfdThumbnailProps) {
+  const { data: nfdData, isLoading, error } = useQuery(nfdQueryOptions(nameOrId || ''))
+  const nfd = nfdProp || nfdData
 
   if (isLoading) {
     return <span className="text-sm">Loading...</span>
   }
 
   if (error || !nfd) {
-    return <span className="text-sm text-red-500">Error fetching balance</span>
+    return <span className="text-sm text-red-500">Error fetching NFD</span>
   }
 
-  if (link) {
-    return (
-      <a
-        href={getNfdProfileUrl(nfd.name)}
-        target="_blank"
-        rel="noreferrer"
-        className="inline-flex items-center gap-x-1.5 text-sm font-semibold text-foreground/75 hover:text-foreground hover:underline underline-offset-4"
-      >
+  const defaultClassName = 'flex items-center gap-x-1.5 text-sm font-semibold text-foreground'
+
+  const renderChildren = () => (
+    <>
+      <div className="flex-shrink-0">
         <NfdAvatar nfd={nfd} className="h-6 w-6" />
-        {nfd.name}
-      </a>
+      </div>
+      <div className={cn({ truncate })}>{nfd.name}</div>
+    </>
+  )
+
+  const renderThumbnail = () => (
+    <div className={cn(defaultClassName, className)}>{renderChildren()}</div>
+  )
+
+  const renderLink = () => (
+    <a
+      href={getNfdProfileUrl(nfd.name)}
+      target="_blank"
+      rel="noreferrer"
+      className={cn(
+        defaultClassName,
+        'text-foreground/75 hover:text-foreground hover:underline underline-offset-4',
+        className,
+      )}
+    >
+      {renderChildren()}
+    </a>
+  )
+
+  const renderContent = () => (link ? renderLink() : renderThumbnail())
+
+  if (tooltip) {
+    return (
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>{renderContent()}</TooltipTrigger>
+          <TooltipContent className="bg-stone-900 text-white font-semibold tracking-tight dark:bg-white dark:text-stone-900">
+            {nfd.name}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     )
   }
 
-  return (
-    <div className="flex items-center gap-x-1.5 text-sm font-semibold text-foreground">
-      <NfdAvatar nfd={nfd} className="h-6 w-6" />
-      {nfd.name}
-    </div>
-  )
+  return renderContent()
 }
+
+const NfdThumbnail = (props: NfdThumbnailProps) => {
+  const MemoizedNfdThumbnail = React.memo(NfdThumbnailBase)
+
+  if (props.nfd) {
+    return <MemoizedNfdThumbnail {...props} />
+  } else {
+    return <NfdThumbnailBase {...props} />
+  }
+}
+
+export { NfdThumbnail }

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -84,27 +84,29 @@ export function ValidatorTable({
   const columns: ColumnDef<Validator>[] = [
     {
       id: 'validator',
-      accessorFn: (row) => row.config.owner,
+      accessorFn: (row) => row.nfd?.name || row.config.owner.toLowerCase(),
       header: ({ column }) => <DataTableColumnHeader column={column} title="Validator" />,
       cell: ({ row }) => {
         const validator = row.original
-        const nfdAppId = validator.config.nfdForInfo
+        const nfd = validator.nfd
 
         return (
-          <Link
-            to="/validators/$validatorId"
-            params={{
-              validatorId: String(validator.id),
-            }}
-            className="hover:underline underline-offset-4"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {nfdAppId > 0 ? (
-              <NfdThumbnail nameOrId={nfdAppId} />
-            ) : (
-              ellipseAddress(validator.config.owner)
-            )}
-          </Link>
+          <div className="flex min-w-0 max-w-[9rem]">
+            <Link
+              to="/validators/$validatorId"
+              params={{
+                validatorId: String(validator.id),
+              }}
+              className="truncate hover:underline underline-offset-4"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {nfd ? (
+                <NfdThumbnail nfd={nfd} truncate tooltip />
+              ) : (
+                ellipseAddress(validator.config.owner)
+              )}
+            </Link>
+          </div>
         )
       },
     },

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -83,11 +83,6 @@ export function ValidatorTable({
 
   const columns: ColumnDef<Validator>[] = [
     {
-      accessorKey: 'id',
-      header: ({ column }) => <DataTableColumnHeader column={column} title="ID" />,
-      size: 70,
-    },
-    {
       id: 'validator',
       accessorFn: (row) => row.config.owner,
       header: ({ column }) => <DataTableColumnHeader column={column} title="Validator" />,

--- a/ui/src/interfaces/validator.ts
+++ b/ui/src/interfaces/validator.ts
@@ -1,3 +1,4 @@
+import { Nfd } from '@/interfaces/nfd'
 import { ToStringTypes } from '@/interfaces/utils'
 
 export type RawValidatorConfig = [
@@ -85,6 +86,7 @@ export type Validator = {
   pools: PoolInfo[]
   tokenPayoutRatio: number[]
   nodePoolAssignment: NodePoolAssignmentConfig
+  nfd?: Nfd
 }
 
 export interface ValidatorPoolKey {


### PR DESCRIPTION
This makes a few changes to improve the way NFDs are displayed in the validator table:

- the Validator column has a max width set and the `NfdThumbnail` can be truncated for long names
- a boolean `tooltip` prop will show potentially-truncated NFD names in full in a tooltip on hover
- NFD data is fetched up front along with validator data so it's not being fetched asynchronously in the table cell
- `NfdThumbnail` can either accept a `nameOrId` prop (to fetch) or an NFD object if the data is already available
- `NfdThumbnail` is conditionally memoized if the data is passed in as a prop to limit unnecessary re-renders
- `NfdAvatar` is memoized