### PR TITLE
fix(ui): invalidate cached queries on pool/stake mutation

### DIFF
--- a/ui/src/components/AddPoolModal.tsx
+++ b/ui/src/components/AddPoolModal.tsx
@@ -126,20 +126,7 @@ export function AddPoolModal({
         duration: 5000,
       })
 
-      queryClient.setQueryData<Validator>(['validator', String(validator!.id)], (prevData) => {
-        if (!prevData) {
-          return prevData
-        }
-
-        return {
-          ...prevData,
-          state: {
-            ...prevData.state,
-            numPools: prevData.state.numPools + 1,
-          },
-        }
-      })
-
+      // Manually update ['validators'] query to avoid refetching
       queryClient.setQueryData<Validator[]>(['validators'], (prevData) => {
         if (!prevData) {
           return prevData
@@ -160,8 +147,11 @@ export function AddPoolModal({
         })
       })
 
-      router.invalidate()
+      // Invalidate other queries to update UI
+      queryClient.invalidateQueries({ queryKey: ['validator', String(validator!.id)] })
       queryClient.invalidateQueries({ queryKey: ['pool-assignments', validator!.id] })
+      queryClient.invalidateQueries({ queryKey: ['validator-pools', validator!.id] })
+      router.invalidate()
     } catch (error) {
       toast.error('Failed to create staking pool', { id: toastId })
       console.error(error)


### PR DESCRIPTION
Previously optimistic updates were used to update the cache after a pool or stake mutation. This is cumbersome and prone to errors, since the logic to immutably update deeply-nested data in multiple queries can be complex.

Instead, we now invalidate the cache for queries that return validator, pool, or stake data that was mutated. This is done by calling `invalidateQueries` with a predicate that matches the keys of the affected queries, then calling `router.invalidate()` to trigger refetches.

To avoid refetching all (mostly unaffected) validators, the `['validators']` query is still optimistically updated as before.