### PR TITLE
fix(nodemgr): Monitor the manager address changing and gracefully exit

### DIFF
--- a/nodemgr/internal/lib/reti/reti.go
+++ b/nodemgr/internal/lib/reti/reti.go
@@ -44,7 +44,7 @@ func (r *Reti) Info() ValidatorInfo {
 	return r.info
 }
 
-func (r *Reti) SetInfo(Info ValidatorInfo) {
+func (r *Reti) setInfo(Info ValidatorInfo) {
 	r.Lock()
 	defer r.Unlock()
 	r.info = Info
@@ -178,7 +178,7 @@ func (r *Reti) LoadState(ctx context.Context) error {
 		promAmtConsideredSaturated.Set(float64(constraints.AmtConsideredSaturated) / 1e6)
 		promMaxStakeAllowed.Set(float64(constraints.MaxAlgoPerValidator) / 1e6)
 
-		r.SetInfo(newInfo)
+		r.setInfo(newInfo)
 	}
 	return nil
 }


### PR DESCRIPTION
Exit the daemon on manager address change so that on restart the new manager address is used and keys verified.
Otherwise, mnemonics for new manager might not be available for subsequent transactions.