### PR TITLE
feat(ui): support simulate calls from rekeyed accounts

### DIFF
--- a/ui/src/components/AddStakeModal.tsx
+++ b/ui/src/components/AddStakeModal.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
 import { Constraints, Validator } from '@/interfaces/validator'
+import { useAuthAddress } from '@/providers/AuthAddressProvider'
 import {
   fetchGatingAssets,
   findQualifiedGatingAssetId,
@@ -64,6 +65,7 @@ export function AddStakeModal({ validator, setValidator, constraints }: AddStake
   const queryClient = useQueryClient()
   const router = useRouter()
   const { transactionSigner, activeAddress } = useWallet()
+  const { authAddress, isReady } = useAuthAddress()
 
   const accountInfoQuery = useQuery({
     queryKey: ['account-info', activeAddress],
@@ -101,8 +103,8 @@ export function AddStakeModal({ validator, setValidator, constraints }: AddStake
   // @todo: make this a custom hook, call from higher up and pass down as prop
   const mbrRequiredQuery = useQuery({
     queryKey: ['mbr-required', activeAddress],
-    queryFn: () => doesStakerNeedToPayMbr(activeAddress!),
-    enabled: !!activeAddress,
+    queryFn: () => doesStakerNeedToPayMbr(activeAddress!, authAddress),
+    enabled: !!activeAddress && isReady,
     staleTime: Infinity,
   })
   const mbrRequired = mbrRequiredQuery.data || false
@@ -247,6 +249,7 @@ export function AddStakeModal({ validator, setValidator, constraints }: AddStake
         valueToVerify,
         transactionSigner,
         activeAddress,
+        authAddress,
       )
 
       toast.success(

--- a/ui/src/components/AddValidatorForm.tsx
+++ b/ui/src/components/AddValidatorForm.tsx
@@ -37,6 +37,7 @@ import {
   GATING_TYPE_SEGMENT_OF_NFD,
 } from '@/constants/gating'
 import { Constraints } from '@/interfaces/validator'
+import { useAuthAddress } from '@/providers/AuthAddressProvider'
 import {
   getAddValidatorFormSchema,
   getEpochLengthMinutes,
@@ -64,6 +65,7 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
   const [isSigning, setIsSigning] = React.useState(false)
 
   const { transactionSigner, activeAddress } = useWallet()
+  const { authAddress } = useAuthAddress()
 
   const navigate = useNavigate({ from: '/add' })
 
@@ -238,6 +240,7 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
         nfdForInfoAppId,
         transactionSigner,
         activeAddress,
+        authAddress,
       )
 
       toast.success(

--- a/ui/src/components/StakingTable.tsx
+++ b/ui/src/components/StakingTable.tsx
@@ -39,6 +39,7 @@ import {
 import { UnstakeModal } from '@/components/UnstakeModal'
 import { StakerValidatorData } from '@/interfaces/staking'
 import { Constraints, Validator } from '@/interfaces/validator'
+import { useAuthAddress } from '@/providers/AuthAddressProvider'
 import { canManageValidator, isStakingDisabled, isUnstakingDisabled } from '@/utils/contracts'
 import { simulateEpoch } from '@/utils/development'
 import { ellipseAddress } from '@/utils/ellipseAddress'
@@ -66,6 +67,7 @@ export function StakingTable({
   const [unstakeValidator, setUnstakeValidator] = React.useState<Validator | null>(null)
 
   const { transactionSigner, activeAddress } = useWallet()
+  const { authAddress } = useAuthAddress()
 
   const router = useRouter()
   const queryClient = useQueryClient()
@@ -198,6 +200,7 @@ export function StakingTable({
                             100,
                             transactionSigner,
                             activeAddress,
+                            authAddress,
                             queryClient,
                             router,
                           )

--- a/ui/src/components/UnstakeModal.tsx
+++ b/ui/src/components/UnstakeModal.tsx
@@ -37,6 +37,7 @@ import {
 } from '@/components/ui/select'
 import { StakerPoolData, StakerValidatorData } from '@/interfaces/staking'
 import { Validator } from '@/interfaces/validator'
+import { useAuthAddress } from '@/providers/AuthAddressProvider'
 import { formatAlgoAmount } from '@/utils/format'
 
 interface UnstakeModalProps {
@@ -70,6 +71,7 @@ export function UnstakeModal({ validator, setValidator, stakesByValidator }: Uns
   const queryClient = useQueryClient()
   const router = useRouter()
   const { transactionSigner, activeAddress } = useWallet()
+  const { authAddress } = useAuthAddress()
 
   const formSchema = z.object({
     amountToUnstake: z
@@ -180,7 +182,13 @@ export function UnstakeModal({ validator, setValidator, stakesByValidator }: Uns
 
       toast.loading('Sign transactions to remove stake...', { id: toastId })
 
-      await removeStake(pool.poolKey.poolAppId, amountToUnstake, transactionSigner, activeAddress)
+      await removeStake(
+        pool.poolKey.poolAppId,
+        amountToUnstake,
+        transactionSigner,
+        activeAddress,
+        authAddress,
+      )
 
       toast.success(
         <div className="flex items-center gap-x-2">

--- a/ui/src/lib/makeEmptyTransactionSigner.ts
+++ b/ui/src/lib/makeEmptyTransactionSigner.ts
@@ -1,0 +1,32 @@
+import algosdk, { Transaction, TransactionSigner, EncodedSignedTransaction } from 'algosdk'
+
+/**
+ * This is a "polyfill" for algosdk's `makeEmptyTransactionSigner` function that supports simulate
+ * calls from rekeyed accounts.
+ * @see https://github.com/algorand/go-algorand/issues/5914
+ *
+ * @param {string} authAddr - Optional authorized address (spending key) for a rekeyed account.
+ * @returns A function that can be used with simulate w/ the "allow empty signatures" option.
+ */
+export const makeEmptyTransactionSigner = (authAddr?: string): TransactionSigner => {
+  return async (txns: Transaction[], indexesToSign: number[]): Promise<Uint8Array[]> => {
+    const emptySigTxns: Uint8Array[] = []
+
+    indexesToSign.forEach((i) => {
+      const encodedStxn: EncodedSignedTransaction = {
+        txn: txns[i].get_obj_for_encoding(),
+      }
+
+      // If authAddr is provided, use its decoded publicKey as the signer
+      if (authAddr) {
+        const { publicKey } = algosdk.decodeAddress(authAddr)
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        encodedStxn.sgnr = publicKey as any as Buffer
+      }
+
+      emptySigTxns.push(algosdk.encodeObj(encodedStxn))
+    })
+
+    return emptySigTxns
+  }
+}

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -14,14 +14,15 @@ import { HelmetProvider } from 'react-helmet-async'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import { Toaster } from '@/components/ui/sonner'
 import { WalletShortcutHandler } from '@/components/WalletShortcutHandler'
+import { AuthAddressProvider } from '@/providers/AuthAddressProvider'
 import { ThemeProvider } from '@/providers/ThemeProvider'
+import { routeTree } from '@/routeTree.gen'
 import '@/styles/main.css'
 import {
   getAlgodConfigFromViteEnvironment,
   getAlgodNetwork,
   getKmdConfigFromViteEnvironment,
 } from '@/utils/network/getAlgoClientConfigs'
-import { routeTree } from './routeTree.gen'
 
 // use-wallet configuration
 let wallets: SupportedWallet[]
@@ -96,8 +97,10 @@ function AppProviders() {
         <QueryClientProvider client={queryClient}>
           <SnackbarProvider maxSnack={3}>
             <WalletProvider manager={walletManager}>
-              <InnerApp />
-              <WalletShortcutHandler />
+              <AuthAddressProvider>
+                <InnerApp />
+                <WalletShortcutHandler />
+              </AuthAddressProvider>
             </WalletProvider>
           </SnackbarProvider>
         </QueryClientProvider>

--- a/ui/src/providers/AuthAddressProvider.tsx
+++ b/ui/src/providers/AuthAddressProvider.tsx
@@ -1,0 +1,53 @@
+import { useWallet } from '@txnlab/use-wallet-react'
+import * as React from 'react'
+import { getAccountInformation } from '@/api/algod'
+
+interface IContext {
+  authAddress: string | undefined
+  isReady: boolean
+}
+
+const AuthAddressContext = React.createContext<IContext>({} as IContext)
+
+export const useAuthAddress = (): IContext => {
+  const context = React.useContext(AuthAddressContext)
+  if (!context) {
+    throw new Error('useAuthAddress must be used within a AuthAddressProvider')
+  }
+  return context
+}
+
+export function AuthAddressProvider({ children }: { children: React.ReactNode }): JSX.Element {
+  const [authAddress, setAuthAddress] = React.useState<string | undefined>(undefined)
+  const [isReady, setIsReady] = React.useState<boolean>(false)
+
+  const { activeAddress } = useWallet()
+
+  React.useEffect(() => {
+    const fetchAuthAddress = async () => {
+      try {
+        const accountInfo = await getAccountInformation(activeAddress!, 'all')
+        const authAddr = accountInfo['auth-addr']
+        setAuthAddress(authAddr)
+      } catch (error) {
+        console.error(`Error fetching active wallet's authorized address:`, error)
+        setAuthAddress(activeAddress!)
+      } finally {
+        setIsReady(true)
+      }
+    }
+
+    if (activeAddress) {
+      setIsReady(false)
+      fetchAuthAddress()
+    } else {
+      setAuthAddress(undefined)
+    }
+  }, [activeAddress])
+
+  return (
+    <AuthAddressContext.Provider value={{ authAddress, isReady }}>
+      {children}
+    </AuthAddressContext.Provider>
+  )
+}

--- a/ui/src/providers/AuthAddressProvider.tsx
+++ b/ui/src/providers/AuthAddressProvider.tsx
@@ -31,7 +31,7 @@ export function AuthAddressProvider({ children }: { children: React.ReactNode })
         setAuthAddress(authAddr)
       } catch (error) {
         console.error(`Error fetching active wallet's authorized address:`, error)
-        setAuthAddress(activeAddress!)
+        setAuthAddress(undefined)
       } finally {
         setIsReady(true)
       }

--- a/ui/src/utils/development.ts
+++ b/ui/src/utils/development.ts
@@ -26,6 +26,7 @@ export async function simulateEpoch(
   rewardAmount: number,
   signer: algosdk.TransactionSigner,
   activeAddress: string,
+  authAddr: string | undefined,
   queryClient: QueryClient,
   router: ReturnType<typeof useRouter>,
 ) {
@@ -70,7 +71,7 @@ export async function simulateEpoch(
       const poolKey = pool.poolKey
       toast.loading(`Sign for Pool ${poolKey.poolId} epoch balance update`, { id: toastId })
 
-      await epochBalanceUpdate(poolKey.poolAppId, signer, activeAddress)
+      await epochBalanceUpdate(poolKey.poolAppId, signer, activeAddress, authAddr)
     }
 
     toast.success('Epoch balance update complete!', { id: toastId })


### PR DESCRIPTION
Using the algosdk v2.7.0 `makeEmptyTransactionSigner` function for simulate calls with the "allow empty signatures" option currently fails if the sender is a rekeyed account.

This solution is based on the workaround @joe-p offered in a discussion about the issue: https://github.com/algorand/go-algorand/issues/5914#issuecomment-1904781807

A React Context provider contains an effect that runs whenever use-wallet's `activeAddress` changes, looking on-chain to see if the account has been rekeyed. If so, its authorized address (spending key) is stored and exposed by the `useAuthAddress` hook where it can be accessed anywhere in the app.

Any function that makes a contract call using simulate from the active account now also accepts an additional `authAddr` argument, which is then passed to the "polyfilled" `makeEmptyTransactionSigner` function.

A future release of https://github.com/TxnLab/use-wallet will handle fetching and exposing the active account's `authAddress` (if it exists) along with the `activeAddress` and this Context provider solution can be replaced.