### PR TITLE
feat(ui): simulate donut chart clicks on dropdown change

### DIFF
--- a/ui/src/components/ValidatorDetails/PoolsChart.tsx
+++ b/ui/src/components/ValidatorDetails/PoolsChart.tsx
@@ -1,6 +1,5 @@
 import { DonutChart, EventProps } from '@tremor/react'
 import { AlgoDisplayAmount } from '@/components/AlgoDisplayAmount'
-import { convertToBaseUnits } from '@/utils/format'
 
 type PoolData = {
   name: string
@@ -70,7 +69,7 @@ function customTooltip(props: CustomTooltipTypeDonut) {
   if (!categoryPayload) return null
 
   // Pools with no stake are set to 1 microalgo for the chart, but tooltip should show correct total (0)
-  const algoAmount = convertToBaseUnits(categoryPayload.value, 6) === 1 ? 0 : categoryPayload.value
+  const algoAmount = categoryPayload.value === 0.000001 ? 0 : categoryPayload.value
 
   return (
     <div className="w-56 rounded-tremor-default border border-tremor-border bg-tremor-background p-2 text-tremor-default shadow-tremor-dropdown dark:border-dark-tremor-border dark:bg-stone-950">

--- a/ui/src/components/ValidatorDetails/PoolsChart.tsx
+++ b/ui/src/components/ValidatorDetails/PoolsChart.tsx
@@ -1,5 +1,6 @@
 import { DonutChart, EventProps } from '@tremor/react'
 import { AlgoDisplayAmount } from '@/components/AlgoDisplayAmount'
+import { convertToBaseUnits } from '@/utils/format'
 
 type PoolData = {
   name: string
@@ -68,6 +69,9 @@ function customTooltip(props: CustomTooltipTypeDonut) {
   const categoryPayload = payload?.[0]
   if (!categoryPayload) return null
 
+  // Pools with no stake are set to 1 microalgo for the chart, but tooltip should show correct total (0)
+  const algoAmount = convertToBaseUnits(categoryPayload.value, 6) === 1 ? 0 : categoryPayload.value
+
   return (
     <div className="w-56 rounded-tremor-default border border-tremor-border bg-tremor-background p-2 text-tremor-default shadow-tremor-dropdown dark:border-dark-tremor-border dark:bg-stone-950">
       <div className="flex flex-1 space-x-2.5">
@@ -79,7 +83,7 @@ function customTooltip(props: CustomTooltipTypeDonut) {
             </p>
             <p className="whitespace-nowrap text-right text-tremor-content-emphasis dark:text-dark-tremor-content-emphasis">
               <AlgoDisplayAmount
-                amount={categoryPayload.value}
+                amount={algoAmount}
                 maxLength={13}
                 compactPrecision={2}
                 mutedRemainder

--- a/ui/src/components/ValidatorDetails/StakingDetails.tsx
+++ b/ui/src/components/ValidatorDetails/StakingDetails.tsx
@@ -45,10 +45,11 @@ export function StakingDetails({ validator, constraints, stakesByValidator }: St
   const stakingDisabled = isStakingDisabled(activeAddress, validator, constraints)
   const unstakingDisabled = isUnstakingDisabled(activeAddress, validator, stakesByValidator)
 
+  // If pool has no stake, set value to 1 microalgo so it appears in the donut chart (as a 1px sliver)
   const poolData =
     validator?.pools.map((pool, index) => ({
       name: `Pool ${index + 1}`,
-      value: convertFromBaseUnits(Number(pool.totalAlgoStaked), 6),
+      value: convertFromBaseUnits(Number(pool.totalAlgoStaked || 1n), 6),
     })) || []
 
   const poolsInfoQuery = useQuery(validatorPoolsQueryOptions(validator.id))
@@ -130,6 +131,46 @@ export function StakingDetails({ validator, constraints, stakesByValidator }: St
   const handlePoolClick = (eventProps: EventProps) => {
     const selected = !eventProps ? 'all' : getPoolIndexFromName(eventProps.name, true)
     setSelectedPool(selected)
+  }
+
+  const poolsChartContainerRef = React.useRef<HTMLDivElement>(null)
+
+  // Function to simulate clicking a pool in the donut chart
+  const simulateClick = (name: string) => {
+    if (poolsChartContainerRef.current) {
+      const targetElement = poolsChartContainerRef.current.querySelector(
+        `path[name="${name}"]`,
+      ) as SVGPathElement | null
+      if (targetElement) {
+        const clickEvent = new MouseEvent('click', {
+          view: window,
+          bubbles: true,
+          cancelable: true,
+        })
+        targetElement.dispatchEvent(clickEvent)
+      }
+    }
+  }
+
+  // Function to handle the change of the selected pool via the dropdown
+  const handleSelectValueChange = (newValue: string) => {
+    const previousValue = selectedPool
+    const previousPool = getPoolNameFromIndex(previousValue)
+    const newPool = getPoolNameFromIndex(newValue)
+
+    if (previousValue === 'all') {
+      // Switching from 'All Pools' to a specific pool, click new pool to select
+      simulateClick(newPool)
+    } else if (newValue === 'all') {
+      // Switching from a specific pool to 'All Pools', click previous pool to deselect
+      simulateClick(previousPool)
+    } else {
+      // Switching between two specific pools, click previous pool to deselect then new pool to select
+      simulateClick(previousPool)
+      simulateClick(newPool)
+    }
+
+    setSelectedPool(newValue)
   }
 
   const selectedPoolInfo = selectedPool === 'all' ? null : poolsInfo[Number(selectedPool)]
@@ -305,7 +346,7 @@ export function StakingDetails({ validator, constraints, stakesByValidator }: St
           <CardTitle className="flex items-start justify-between gap-x-2">
             <span>Staking Details</span>
             {poolsInfo.length > 0 && (
-              <Select value={selectedPool} onValueChange={setSelectedPool}>
+              <Select value={selectedPool} onValueChange={handleSelectValueChange}>
                 <SelectTrigger className="-my-2.5 w-[120px]">
                   <SelectValue placeholder="Select a pool" />
                 </SelectTrigger>
@@ -323,7 +364,7 @@ export function StakingDetails({ validator, constraints, stakesByValidator }: St
         </CardHeader>
         <CardContent className="mt-2.5 space-y-6">
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
-            <div className="flex items-center justify-center">
+            <div ref={poolsChartContainerRef} className="flex items-center justify-center">
               {poolData.filter((data) => data.value > 0).length > 0 ? (
                 <PoolsChart
                   data={poolData}

--- a/ui/src/components/ValidatorDetails/StakingDetails.tsx
+++ b/ui/src/components/ValidatorDetails/StakingDetails.tsx
@@ -365,7 +365,7 @@ export function StakingDetails({ validator, constraints, stakesByValidator }: St
         <CardContent className="mt-2.5 space-y-6">
           <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
             <div ref={poolsChartContainerRef} className="flex items-center justify-center">
-              {poolData.filter((data) => data.value > 0).length > 0 ? (
+              {poolData.filter((data) => data.value > 0.000001).length > 0 ? (
                 <PoolsChart
                   data={poolData}
                   onValueChange={handlePoolClick}


### PR DESCRIPTION
The only way to highlight a pool in the donut chart is to click it. This simulates that behavior when selecting a pool from the dropdown menu in StakingDetails.

When selecting a pool from the menu, the donut chart will highlight the corresponding pool. It will reset if "All Pools" is selected.

If a staking pool has no stake, it must still appear in the chart for this to work. The solution here is a bit of a hack: in the chart, pools with no stake are set to 1 microalgo. It is displayed as a barely perceptible sliver in the chart, but it is enough to allow the chart to highlight the pool when selected from the dropdown. Its tooltip shows the correct amount of 0 stake.