### PR TITLE
feat(ui): AddStakeModal improvements

### DIFF
--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -10,6 +10,7 @@ import { StakedInfo, StakerPoolData, StakerValidatorData } from '@/interfaces/st
 import {
   Constraints,
   EntryGatingAssets,
+  FindPoolForStakerResponse,
   MbrAmounts,
   NodePoolAssignmentConfig,
   PoolInfo,
@@ -557,6 +558,50 @@ export async function doesStakerNeedToPayMbr(
     .simulate({ allowEmptySignatures: true, allowUnnamedResources: true })
 
   return result.returns![0]
+}
+
+export async function findPoolForStaker(
+  validatorId: number,
+  amountToStake: number,
+  activeAddress: string,
+  authAddr?: string,
+  client?: ValidatorRegistryClient,
+): Promise<FindPoolForStakerResponse> {
+  const validatorClient = client || makeSimulateValidatorClient(activeAddress, authAddr)
+
+  const result = await validatorClient
+    .compose()
+    .gas({})
+    .findPoolForStaker(
+      {
+        validatorId,
+        staker: activeAddress,
+        amountToStake,
+      },
+      {
+        sendParams: {
+          fee: AlgoAmount.MicroAlgos(2000),
+        },
+      },
+    )
+    .simulate({ allowEmptySignatures: true, allowUnnamedResources: true })
+
+  const errorMessage = result.simulateResponse.txnGroups[0].failureMessage
+
+  if (errorMessage || !result.returns[1]) {
+    throw new Error(`Error finding pool for staker: ${errorMessage || 'No pool found'}`)
+  }
+
+  const [[valId, poolId, poolAppId], isNewStakerToValidator, isNewStakerToProtocol] =
+    result.returns[1]
+
+  const poolKey: ValidatorPoolKey = {
+    validatorId: Number(valId),
+    poolId: Number(poolId),
+    poolAppId: Number(poolAppId),
+  }
+
+  return { poolKey, isNewStakerToValidator, isNewStakerToProtocol }
 }
 
 export async function addStake(

--- a/ui/src/components/StakingTable.tsx
+++ b/ui/src/components/StakingTable.tsx
@@ -297,6 +297,7 @@ export function StakingTable({
       <AddStakeModal
         validator={addStakeValidator}
         setValidator={setAddStakeValidator}
+        stakesByValidator={stakesByValidator}
         constraints={constraints}
       />
       <UnstakeModal

--- a/ui/src/components/UnstakeModal.tsx
+++ b/ui/src/components/UnstakeModal.tsx
@@ -136,6 +136,7 @@ export function UnstakeModal({ validator, setValidator, stakesByValidator }: Uns
         setValidator(null)
         setSelectedPoolId('')
         form.setValue('amountToUnstake', '')
+        form.clearErrors()
       }, 500)
     }
   }

--- a/ui/src/components/ValidatorDetails/StakingDetails.tsx
+++ b/ui/src/components/ValidatorDetails/StakingDetails.tsx
@@ -373,6 +373,7 @@ export function StakingDetails({ validator, constraints, stakesByValidator }: St
       <AddStakeModal
         validator={addStakeValidator}
         setValidator={setAddStakeValidator}
+        stakesByValidator={stakesByValidator}
         constraints={constraints}
       />
       <UnstakeModal

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -407,6 +407,7 @@ export function ValidatorTable({
       <AddStakeModal
         validator={addStakeValidator}
         setValidator={setAddStakeValidator}
+        stakesByValidator={stakesByValidator}
         constraints={constraints}
       />
       <UnstakeModal

--- a/ui/src/components/ui/alert.tsx
+++ b/ui/src/components/ui/alert.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/utils/ui'
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7',
+  {
+    variants: {
+      variant: {
+        default: 'bg-background text-foreground',
+        destructive:
+          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
+))
+Alert.displayName = 'Alert'
+
+const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h5
+      ref={ref}
+      className={cn('mb-1 font-medium leading-none tracking-tight', className)}
+      {...props}
+    />
+  ),
+)
+AlertTitle.displayName = 'AlertTitle'
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('text-sm [&_p]:leading-relaxed', className)} {...props} />
+))
+AlertDescription.displayName = 'AlertDescription'
+
+export { Alert, AlertTitle, AlertDescription }

--- a/ui/src/interfaces/validator.ts
+++ b/ui/src/interfaces/validator.ts
@@ -100,6 +100,12 @@ export interface ValidatorPoolKey {
   validatorId: number
 }
 
+export interface FindPoolForStakerResponse {
+  poolKey: ValidatorPoolKey
+  isNewStakerToValidator: boolean
+  isNewStakerToProtocol: boolean
+}
+
 export interface MbrAmounts {
   validatorMbr: number
   poolMbr: number

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -752,3 +752,22 @@ export function findQualifiedGatingAssetId(
   )
   return asset?.['asset-id'] || 0
 }
+
+export function calculateMaxAvailableToStake(validator: Validator, constraints?: Constraints) {
+  let { maxAlgoPerPool } = validator.config
+
+  if (maxAlgoPerPool === 0n) {
+    if (!constraints) {
+      return 0
+    }
+    maxAlgoPerPool = constraints.maxAlgoPerPool
+  }
+
+  // For each pool, subtract the totalAlgoStaked from maxAlgoPerPool and return the highest value
+  const maxAvailableToStake = validator.pools.reduce((acc, pool) => {
+    const availableToStake = Number(maxAlgoPerPool) - Number(pool.totalAlgoStaked)
+    return availableToStake > acc ? availableToStake : acc
+  }, 0)
+
+  return maxAvailableToStake
+}


### PR DESCRIPTION
- Shows available balance to stake
- Shows target pool depending on the stake amount entered
- Fixes minimum stake validation (only enforce minimum entry stake if first time staking to validator)
- Fixes maximum available to stake calculation, using protocol constraints if `maxAlgoPerPool` is not set in validator config
- Clears any errors when the modal is closed
- Nicer "first time stakers fee" message, shown in an alert/callout