### PR TITLE
refactor(ui): use dayjs to calculate reward eligibility

### DIFF
--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -19,6 +19,12 @@ jobs:
     name: Lint, Typecheck, Test, and Build
     runs-on: ubuntu-latest
 
+    env:
+      VITE_ALGOD_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      VITE_ALGOD_SERVER: http://localhost
+      VITE_ALGOD_PORT: 4001
+      VITE_ALGOD_NETWORK: localnet
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -23,7 +23,8 @@ jobs:
       VITE_ALGOD_TOKEN: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       VITE_ALGOD_SERVER: http://localhost
       VITE_ALGOD_PORT: 4001
-      VITE_ALGOD_NETWORK: localnet
+      VITE_NFD_API_URL: http://localhost:80
+      VITE_NFD_APP_URL: ws://localhost:3000
 
     steps:
       - name: Checkout repository

--- a/ui/.env.test
+++ b/ui/.env.test
@@ -1,0 +1,9 @@
+# Algod
+VITE_ALGOD_TOKEN=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+VITE_ALGOD_SERVER=http://localhost
+VITE_ALGOD_PORT=4001
+
+# NFDomains
+VITE_NFD_API_URL=http://localhost:80
+VITE_NFD_APP_URL=http://localhost:3000
+

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -17,6 +17,7 @@
 .env.localnet
 .env.testnet
 .env.mainnet
+!.env.test
 env/
 
 # misc

--- a/ui/package.json
+++ b/ui/package.json
@@ -93,6 +93,7 @@
     "dev:mainnet": "vite --mode mainnet --port 5193",
     "build": "tsc && vite build",
     "test": "vitest",
+    "test:watch": "vitest --watch",
     "coverage": "vitest --coverage",
     "playwright:test": "playwright test",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",

--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -32,6 +32,7 @@ import {
   transformStakedInfo,
   transformValidatorData,
 } from '@/utils/contracts'
+import { dayjs } from '@/utils/dayjs'
 import { getRetiAppIdFromViteEnvironment } from '@/utils/env'
 import { getAlgodConfigFromViteEnvironment } from '@/utils/network/getAlgoClientConfigs'
 
@@ -743,9 +744,11 @@ export async function fetchStakerPoolData(
   try {
     const stakingPoolClient = makeSimulateStakingPoolClient(poolKey.poolAppId)
     const stakingPoolGS = await stakingPoolClient.appClient.getGlobalState()
-    let lastPayoutTime: Date = new Date()
+
+    let lastPayoutTime = dayjs()
+
     if (stakingPoolGS.lastPayout !== undefined) {
-      lastPayoutTime = new Date(Number(stakingPoolGS.lastPayout.value as bigint) * 1000)
+      lastPayoutTime = dayjs.unix(Number(stakingPoolGS.lastPayout.value))
     }
 
     const result = await callGetStakerInfo(staker, stakingPoolClient)
@@ -763,7 +766,7 @@ export async function fetchStakerPoolData(
     return {
       ...stakedInfo,
       poolKey,
-      lastPayout: lastPayoutTime.getTime() / 1000,
+      lastPayout: lastPayoutTime.unix(),
     }
   } catch (error) {
     console.error(error)
@@ -805,8 +808,8 @@ export async function fetchStakerValidatorData(staker: string): Promise<StakerVa
         existingData.balance += pool.balance
         existingData.totalRewarded += pool.totalRewarded
         existingData.rewardTokenBalance += pool.rewardTokenBalance
-        existingData.entryTime = Math.min(existingData.entryTime, pool.entryTime)
-        existingData.lastPayout = Math.min(existingData.lastPayout, pool.lastPayout)
+        existingData.entryTime = Math.max(existingData.entryTime, pool.entryTime)
+        existingData.lastPayout = Math.max(existingData.lastPayout, pool.lastPayout)
         existingData.pools.push(pool) // add pool to existing StakerPoolData[]
       } else {
         // First pool for this validator, add new entry

--- a/ui/src/utils/contracts.spec.ts
+++ b/ui/src/utils/contracts.spec.ts
@@ -1,0 +1,72 @@
+import { calculateRewardEligibility } from '@/utils/contracts'
+import { dayjs } from '@/utils/dayjs'
+
+describe('calculateRewardEligibility', () => {
+  let currentTime: dayjs.Dayjs
+
+  beforeEach(() => {
+    currentTime = dayjs()
+  })
+
+  it('should return null if any of the input parameters are zero', () => {
+    expect(calculateRewardEligibility(0, 1625101200, 1625097600)).toBeNull()
+    expect(calculateRewardEligibility(30, 0, 1625097600)).toBeNull()
+    expect(calculateRewardEligibility(30, 1625101200, 0)).toBeNull()
+  })
+
+  it('should return null if any of the input parameters are undefined', () => {
+    expect(calculateRewardEligibility(undefined, 1625101200, 1625097600)).toBeNull()
+    expect(calculateRewardEligibility(30, undefined, 1625097600)).toBeNull()
+    expect(calculateRewardEligibility(30, 1625101200, undefined)).toBeNull()
+  })
+
+  it('should calculate correct percentage when entry time and payout are in the past', () => {
+    const epochLengthMins = 60
+    const lastPoolPayoutTime = currentTime.subtract(45, 'minutes').unix() // Last payout 45 minutes ago
+    const entryTime = currentTime.subtract(15, 'minutes').unix() // Entry time 15 minutes ago
+    expect(calculateRewardEligibility(epochLengthMins, lastPoolPayoutTime, entryTime)).toBe(50)
+  })
+
+  it('should calculate correct percentage when entry time was in previous epoch', () => {
+    const epochLengthMins = 30
+    const lastPoolPayoutTime = currentTime.subtract(20, 'minutes').unix() // Last payout 20 minutes ago
+    const entryTime = currentTime.subtract(45, 'minutes').unix() // Entry time 45 minutes ago
+    expect(calculateRewardEligibility(epochLengthMins, lastPoolPayoutTime, entryTime)).toBe(100)
+  })
+
+  it('should handle edge case where next payout is exactly now', () => {
+    const epochLengthMins = 60
+    const lastPoolPayoutTime = currentTime.subtract(1, 'hour').unix() // Last payout 1 hour ago
+    const entryTime = currentTime.subtract(1, 'hour').unix() // Entry time 1 hour ago
+    expect(calculateRewardEligibility(epochLengthMins, lastPoolPayoutTime, entryTime)).toBe(100)
+  })
+
+  it('should handle postdated entry times correctly', () => {
+    const epochLengthMins = 1
+    const lastPoolPayoutTime = currentTime.subtract(1, 'minutes').unix() // Last payout 1 minute ago
+    const entryTime = currentTime.add(15, 'minutes').unix() // Entry time now (postdated 15 minutes)
+    expect(calculateRewardEligibility(epochLengthMins, lastPoolPayoutTime, entryTime)).toBe(0)
+  })
+
+  it('should round down to the nearest integer', () => {
+    const epochLengthMins = 60 * 4 // 4 hours
+    const lastPoolPayoutTime = currentTime.subtract(3, 'hours').unix() // Last payout 3 hours ago
+    // Entry time 1 hour and 1 minute ago, exact eligibility is 50.416666666666664
+    const entryTime = currentTime.subtract(1, 'hour').subtract(1, 'minute').unix()
+    expect(calculateRewardEligibility(epochLengthMins, lastPoolPayoutTime, entryTime)).toBe(50)
+  })
+
+  it('should never return more than 100%', () => {
+    const epochLengthMins = 60
+    const lastPoolPayoutTime = currentTime.subtract(3, 'hours').unix() // Last payout 3 hours ago
+    const entryTime = currentTime.subtract(2, 'hours').unix() // Entry time 2 hours ago
+    expect(calculateRewardEligibility(epochLengthMins, lastPoolPayoutTime, entryTime)).toBe(100)
+  })
+
+  it('should never return less than 0%', () => {
+    const epochLengthMins = 60
+    const lastPoolPayoutTime = currentTime.unix() // Current time
+    const entryTime = currentTime.add(1, 'hour').unix() // Entry time in the future
+    expect(calculateRewardEligibility(epochLengthMins, lastPoolPayoutTime, entryTime)).toBe(0)
+  })
+})


### PR DESCRIPTION
This refactors the logic to calculate a staker's reward eligibility for display in the dashboard staking table.

The `dayjs` library makes time measurements and calculations more declarative and readable, so issues are easier to debug.

Moving the code to a utility function simplifies the staking column definition in the table and makes the logic testable (unit tests are added).