### PR TITLE
fix(ui): improvements to ValidatorTable UX/display

### DIFF
--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -4,6 +4,7 @@ import {
   ColumnDef,
   ColumnFiltersState,
   SortingState,
+  Updater,
   VisibilityState,
   flexRender,
   getCoreRowModel,
@@ -39,6 +40,7 @@ import {
   TableRow,
 } from '@/components/ui/table'
 import { UnstakeModal } from '@/components/UnstakeModal'
+import { useLocalStorage } from '@/hooks/useLocalStorage'
 import { StakerValidatorData } from '@/interfaces/staking'
 import { Constraints, Validator } from '@/interfaces/validator'
 import {
@@ -66,9 +68,7 @@ export function ValidatorTable({
   stakesByValidator,
   constraints,
 }: ValidatorTableProps) {
-  const [sorting, setSorting] = React.useState<SortingState>([])
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
-  const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({})
   const [rowSelection, setRowSelection] = React.useState({})
 
   const [addStakeValidator, setAddStakeValidator] = React.useState<Validator | null>(null)
@@ -77,6 +77,29 @@ export function ValidatorTable({
 
   const { transactionSigner, activeAddress } = useWallet()
   const navigate = useNavigate()
+
+  const [sorting, setSorting] = useLocalStorage<SortingState>('validator-sorting', [])
+  const handleSortingChange = (updaterOrValue: Updater<SortingState>) => {
+    if (typeof updaterOrValue === 'function') {
+      const newState = updaterOrValue(sorting)
+      setSorting(newState)
+    } else {
+      setSorting(updaterOrValue)
+    }
+  }
+
+  const [columnVisibility, setColumnVisibility] = useLocalStorage<VisibilityState>(
+    'validator-columns',
+    {},
+  )
+  const handleColumnVisibilityChange = (updaterOrValue: Updater<VisibilityState>) => {
+    if (typeof updaterOrValue === 'function') {
+      const newState = updaterOrValue(columnVisibility)
+      setColumnVisibility(newState)
+    } else {
+      setColumnVisibility(updaterOrValue)
+    }
+  }
 
   const columns: ColumnDef<Validator>[] = [
     {
@@ -326,11 +349,11 @@ export function ValidatorTable({
     data: validators,
     columns,
     getCoreRowModel: getCoreRowModel(),
-    onSortingChange: setSorting,
+    onSortingChange: handleSortingChange,
     getSortedRowModel: getSortedRowModel(),
     onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
-    onColumnVisibilityChange: setColumnVisibility,
+    onColumnVisibilityChange: handleColumnVisibilityChange,
     onRowSelectionChange: setRowSelection,
     state: {
       sorting,

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -88,7 +88,7 @@ export function ValidatorTable({
         const nfd = validator.nfd
 
         return (
-          <div className="flex min-w-0 max-w-[9rem]">
+          <div className="flex min-w-0 max-w-[10rem] xl:max-w-[14rem]">
             <Link
               to="/validators/$validatorId"
               params={{
@@ -145,7 +145,7 @@ export function ValidatorTable({
     {
       id: 'pools',
       accessorFn: (row) => row.state.numPools,
-      header: ({ column }) => <DataTableColumnHeader column={column} title="# Pools" />,
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Pools" />,
       cell: ({ row }) => {
         const validator = row.original
         const { poolsPerNode } = validator.config
@@ -181,7 +181,7 @@ export function ValidatorTable({
     {
       id: 'reward',
       accessorFn: (row) => row.state.totalStakers,
-      header: ({ column }) => <DataTableColumnHeader column={column} title="Reward Avail" />,
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Avail. Rewards" />,
       cell: ({ row }) => {
         const validator = row.original
         if (validator.state.numPools == 0) return '--'
@@ -200,12 +200,12 @@ export function ValidatorTable({
       },
     },
     {
-      id: 'payoutFrequency',
+      id: 'epoch',
       accessorFn: (row) => row.config.payoutEveryXMins,
-      header: ({ column }) => <DataTableColumnHeader column={column} title="Payout Frequency" />,
+      header: ({ column }) => <DataTableColumnHeader column={column} title="Epoch" />,
       cell: ({ row }) => {
         const validator = row.original
-        const frequencyFormatted = formatDuration(validator.config.payoutEveryXMins)
+        const frequencyFormatted = formatDuration(validator.config.payoutEveryXMins, true)
         return <span className="capitalize">{frequencyFormatted}</span>
       },
     },

--- a/ui/src/hooks/useLocalStorage.ts
+++ b/ui/src/hooks/useLocalStorage.ts
@@ -1,0 +1,56 @@
+import * as React from 'react'
+
+export const LOCAL_STORAGE_PREFIX = 'reti/'
+
+export interface VersionedStorageConfig<T> {
+  version: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  migrate?: (persistedState: any, version: number) => T
+}
+
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+  config?: VersionedStorageConfig<T>,
+): [T, (value: T) => void] {
+  // Initialize the state with the value from local storage or the provided initial value
+  const [storedValue, setStoredValue] = React.useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(`${LOCAL_STORAGE_PREFIX}${key}`)
+      if (item) {
+        const parsedItem = JSON.parse(item)
+        const storedVersion = parsedItem.version || 0
+        let data = parsedItem.value
+
+        // Version mismatch
+        if (config && storedVersion !== config.version) {
+          // Perform migration if migrate function is provided
+          data = config.migrate?.(data, storedVersion) || initialValue
+        }
+
+        return data
+      }
+      return initialValue
+    } catch (error) {
+      console.error(`Failed to read "${key}" from local storage:`, error)
+      return initialValue
+    }
+  })
+
+  const setValue = (valueOrUpdater: T | ((prevValue: T) => T)) => {
+    try {
+      const valueToStore =
+        valueOrUpdater instanceof Function ? valueOrUpdater(storedValue) : valueOrUpdater
+      setStoredValue(valueToStore)
+      // Save to local storage with version
+      window.localStorage.setItem(
+        `${LOCAL_STORAGE_PREFIX}${key}`,
+        JSON.stringify({ version: config?.version || 0, value: valueToStore }),
+      )
+    } catch (error) {
+      console.error(`Failed to write "${key}" to local storage:`, error)
+    }
+  }
+
+  return [storedValue, setValue]
+}

--- a/ui/src/utils/dayjs.ts
+++ b/ui/src/utils/dayjs.ts
@@ -6,7 +6,7 @@ dayjs.extend(duration)
 dayjs.extend(localizedFormat)
 
 // Utility function to format durations into human-readable strings
-export function formatDuration(minutes: number): string {
+export function formatDuration(minutes: number, compact = false): string {
   // Create a duration object from the given minutes
   const durationObj = dayjs.duration(minutes, 'minutes')
 
@@ -18,18 +18,63 @@ export function formatDuration(minutes: number): string {
   const days = durationObj.days()
   const hours = durationObj.hours()
   const mins = durationObj.minutes()
-  let result = 'every '
+
+  let result = ''
+
+  if (compact) {
+    if (days > 0) {
+      result += `${days}d`
+      if (hours > 0 || mins > 0) result += ' '
+    }
+    if (hours > 0) {
+      result += `${hours}h`
+      if (mins > 0) result += ' '
+    }
+    if (mins > 0) {
+      result += `${mins}m`
+    }
+  } else {
+    result = 'every '
+    if (days > 0) {
+      result += `${days} day${days > 1 ? 's' : ''}`
+      if (hours > 0 || mins > 0) result += ', '
+    }
+    if (hours > 0) {
+      result += `${hours} hour${hours > 1 ? 's' : ''}`
+      if (mins > 0) result += ', '
+    }
+    if (mins > 0) {
+      result += `${mins} minute${mins > 1 ? 's' : ''}`
+    }
+  }
+
+  return result
+}
+
+export function formatCompactDuration(minutes: number): string {
+  // Create a duration object from the given minutes
+  const durationObj = dayjs.duration(minutes, 'minutes')
+
+  // Special cases
+  if (minutes === 1440) return 'daily'
+  if (minutes === 10080) return 'weekly'
+
+  // General case formatting
+  const days = durationObj.days()
+  const hours = durationObj.hours()
+  const mins = durationObj.minutes()
+  let result = ''
 
   if (days > 0) {
-    result += `${days} day${days > 1 ? 's' : ''}`
-    if (hours > 0 || mins > 0) result += ', '
+    result += `${days}d`
+    if (hours > 0 || mins > 0) result += ' '
   }
   if (hours > 0) {
-    result += `${hours} hour${hours > 1 ? 's' : ''}`
-    if (mins > 0) result += ', '
+    result += `${hours}h`
+    if (mins > 0) result += ' '
   }
   if (mins > 0) {
-    result += `${mins} minute${mins > 1 ? 's' : ''}`
+    result += `${mins}m`
   }
 
   return result


### PR DESCRIPTION
This makes two improvements to the `ValidatorTable`:

### Better use of space in ValidatorTable columns
- allow more space for validator name, especially on larger screens
- rename "Payout Frequency" to "Epoch" and display values in compact format
- remove "# " from "# Pools"

### `useLocalStorage` custom hook
- wrapper for `useState` that reads/writes to local storage to persist state
- supports optional versioning and migration, based on Zustand's `persist` middleware: https://github.com/pmndrs/zustand/blob/main/docs/integrations/persisting-store-data.md
- used to persist `ValidatorTable` column sorting/filtering