### PR TITLE
chore(renovate): better grouping and overall config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -48,7 +48,7 @@
         "automerge": true
       },
       {
-        "matchFileNames": ["contracts/**/package.json"],
+        "matchFileNames": ["contracts/package.json"],
         "semanticCommitScope": "contracts",
         "packageRules": [
           {
@@ -61,6 +61,10 @@
             "groupName": "Jest"
           }
         ]
+      },
+      {
+        "matchFileNames": ["contracts/bootstrap/package.json"],
+        "semanticCommitScope": "bootstrap"
       },
       {
         "matchFileNames": ["ui/package.json"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,43 +1,89 @@
 {
-	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"baseBranches": ["dev"],
-	"timezone": "America/New_York",
-	"dependencyDashboard": true,
-	"packageRules": [
-		{
-			"matchFileNames": ["nodemgr/go.mod", "Dockerfile-nodemgr"],
-			"extends": [
-				"config:recommended",
-				"group:allNonMajor",
-				":assignee(pbennett)",
-				":semanticCommitScope(nodemgr)",
-				":semanticPrefixChore"
-			]
-		},
-		{
-			"matchFileNames": ["contracts/**", "**/workflows/release.yaml"],
-			"extends": [
-				"config:recommended",
-				"group:allNonMajor",
-				":assignee(pbennett)",
-				":semanticCommitScope(contracts)",
-				":semanticPrefixChore"
-			]
-		},
-		{
-			"matchFileNames": ["ui/**", "**/workflows/ci-ui.yaml"],
-			"extends": [
-				"config:js-app",
-				"group:allNonMajor",
-				"schedule:earlyMondays",
-				":assignee(drichar)",
-				":combinePatchMinorReleases",
-				":maintainLockFilesWeekly",
-				":rebaseStalePrs",
-				":renovatePrefix",
-				":semanticCommitScope(ui)",
-				":semanticPrefixChore"
-			]
-		}
-	]
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "dependencyDashboard": true,
+  "configMigration": true,
+
+  "timezone": "America/New_York",
+  "assignees": ["pbennett"],
+
+  "baseBranches": ["dev"],
+
+  "separateMultipleMajor": true,
+  "separateMajorMinor": true,
+  "separateMinorPatch": false,
+
+  "packageRules": [
+    {
+      "matchCategories": ["node"],
+      "enabled": false
+    },
+    {
+      "matchFileNames": ["nodemgr/go.mod", "Dockerfile-nodemgr"],
+      "groupName": "Node Manager",
+      "semanticCommitScope": "nodemgr"
+    }
+  ],
+
+  "npm": {
+    "additionalBranchPrefix": "{{{parentDir}}}-",
+    "minimumReleaseAge": "3 days",
+
+    "lockFileMaintenance": {
+      "enabled": true,
+      "schedule": "before 4am on Tuesday",
+      "automerge": true
+    },
+
+    "packageRules": [
+      {
+        "matchDepTypes": ["dependencies", "devDependencies"],
+        "matchUpdateTypes": ["patch", "minor"],
+        "groupName": "non-major dependencies"
+      },
+      {
+        "matchDepTypes": ["devDependencies"],
+        "matchPackagePatterns": ["lint", "prettier"],
+        "groupName": "ESLint/Prettier",
+        "automerge": true
+      },
+      {
+        "matchFileNames": ["contracts/**/package.json"],
+        "semanticCommitScope": "contracts",
+        "packageRules": [
+          {
+            "matchPackageNames": [
+              "@jest/globals",
+              "@types/jest",
+              "jest",
+              "ts-jest"
+            ],
+            "groupName": "Jest"
+          }
+        ]
+      },
+      {
+        "matchFileNames": ["ui/package.json"],
+        "assignees": ["drichar"],
+        "schedule": "before 4am on Monday",
+        "semanticCommitScope": "ui",
+        "rangeStrategy": "pin",
+        "packageRules": [
+          {
+            "matchUpdateTypes": ["pin"],
+            "groupName": "dependency ranges",
+            "automerge": true
+          }
+        ]
+      },
+      {
+        "matchDepTypes": [
+          "optionalDependencies",
+          "peerDependencies",
+          "engines"
+        ],
+        "enabled": false
+      }
+    ]
+  }
 }


### PR DESCRIPTION
What we want for our Renovate configuration is pretty specific, so we can't rely on presets to get the job done. After some research I realized my mental model was wrong and there is a better approach to get the fine-grained control we want.

The crucial difference here in the `npm` config is the `additionalBranchPrefix` setting, which will prepend branches with the name of the package.json's parent folder. This effectively separates all PRs by project: `contracts`, `bootstrap`, and `ui`.

I've set some updates to automerge. Anything related to ESLint/Prettier has 100% coverage in CI (checks will fail if anything breaks), so there's really no reason to manually review and merge. But I'm not sure if this will work since we have a CODEOWNERS file that may require approval before merging. (Edit: yeah, that'll block automerging)

There are lots of other improvements we can make to automate dependency management, but I think this is a good foundation that can be extended in the future.