### PR TITLE
fix(ui): account for no pools in calculateMaxAvailableToStake

### DIFF
--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -764,6 +764,10 @@ export function calculateMaxAvailableToStake(validator: Validator, constraints?:
     maxAlgoPerPool = constraints.maxAlgoPerPool
   }
 
+  if (validator.pools.length === 0) {
+    return Number(maxAlgoPerPool)
+  }
+
   // For each pool, subtract the totalAlgoStaked from maxAlgoPerPool and return the highest value
   const maxAvailableToStake = validator.pools.reduce((acc, pool) => {
     const availableToStake = Number(maxAlgoPerPool) - Number(pool.totalAlgoStaked)


### PR DESCRIPTION
When adding stake to a validator's first pool, bypass the `maxAvailableToStake` reduce function and return `maxAlgoPerPool` from constraints.