### PR TITLE
fix(ui): refetch new validator data instead of manually updating

### DIFF
--- a/ui/src/api/queries.ts
+++ b/ui/src/api/queries.ts
@@ -5,6 +5,7 @@ import {
   fetchNodePoolAssignments,
   fetchProtocolConstraints,
   fetchStakedInfoForPool,
+  fetchStakerValidatorData,
   fetchValidator,
   fetchValidatorPools,
   fetchValidators,
@@ -84,4 +85,13 @@ export const stakedInfoQueryOptions = (poolAppId: number) =>
     queryKey: ['staked-info', poolAppId],
     queryFn: () => fetchStakedInfoForPool(poolAppId),
     enabled: !!poolAppId,
+  })
+
+export const stakesQueryOptions = (staker: string | null) =>
+  queryOptions({
+    queryKey: ['stakes', { staker }],
+    queryFn: () => fetchStakerValidatorData(staker!),
+    enabled: !!staker,
+    retry: false,
+    refetchInterval: 1000 * 60, // every minute
   })

--- a/ui/src/api/queries.ts
+++ b/ui/src/api/queries.ts
@@ -75,7 +75,7 @@ export const nfdQueryOptions = (
 
 export const validatorPoolsQueryOptions = (validatorId: number) =>
   queryOptions({
-    queryKey: ['validator-pools', validatorId],
+    queryKey: ['pools-info', validatorId],
     queryFn: () => fetchValidatorPools(validatorId),
     enabled: !!validatorId,
   })

--- a/ui/src/components/AddPoolModal.tsx
+++ b/ui/src/components/AddPoolModal.tsx
@@ -1,12 +1,16 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { useRouter } from '@tanstack/react-router'
 import { useWallet } from '@txnlab/use-wallet-react'
 import * as React from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import { z } from 'zod'
-import { addStakingPool, fetchMbrAmounts, initStakingPoolStorage } from '@/api/contracts'
+import {
+  addStakingPool,
+  fetchMbrAmounts,
+  fetchValidator,
+  initStakingPoolStorage,
+} from '@/api/contracts'
 import { poolAssignmentQueryOptions } from '@/api/queries'
 import { NodeSelect } from '@/components/NodeSelect'
 import { Button } from '@/components/ui/button'
@@ -26,7 +30,7 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { NodePoolAssignmentConfig, Validator } from '@/interfaces/validator'
-import { findFirstAvailableNode } from '@/utils/contracts'
+import { findFirstAvailableNode, setValidatorQueriesData } from '@/utils/contracts'
 import { cn } from '@/utils/ui'
 
 const formSchema = z.object({
@@ -47,7 +51,6 @@ export function AddPoolModal({
   const [isSigning, setIsSigning] = React.useState<boolean>(false)
 
   const queryClient = useQueryClient()
-  const router = useRouter()
   const { transactionSigner, activeAddress } = useWallet()
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -126,33 +129,11 @@ export function AddPoolModal({
         duration: 5000,
       })
 
-      // Manually update ['validators'] query to avoid refetching
-      queryClient.setQueryData<Validator[]>(['validators'], (prevData) => {
-        if (!prevData) {
-          return prevData
-        }
+      // Refetch validator data
+      const newData = await fetchValidator(validator!.id)
 
-        return prevData.map((validator: Validator) => {
-          if (validator.id === validator!.id) {
-            return {
-              ...validator,
-              state: {
-                ...validator.state,
-                numPools: validator.state.numPools + 1,
-              },
-            }
-          }
-
-          return validator
-        })
-      })
-
-      // Invalidate other queries to update UI
-      queryClient.invalidateQueries({ queryKey: ['validator', String(validator!.id)] })
-      queryClient.invalidateQueries({ queryKey: ['constraints'] })
-      queryClient.invalidateQueries({ queryKey: ['pool-assignments', validator!.id] })
-      queryClient.invalidateQueries({ queryKey: ['validator-pools', validator!.id] })
-      router.invalidate()
+      // Seed/update query cache with new data
+      setValidatorQueriesData(queryClient, newData)
     } catch (error) {
       toast.error('Failed to create staking pool', { id: toastId })
       console.error(error)

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -1,15 +1,13 @@
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
 import { useWallet } from '@txnlab/use-wallet-react'
-import { fetchStakerValidatorData } from '@/api/contracts'
-import { constraintsQueryOptions, validatorsQueryOptions } from '@/api/queries'
+import { constraintsQueryOptions, stakesQueryOptions, validatorsQueryOptions } from '@/api/queries'
 import { Loading } from '@/components/Loading'
 import { Meta } from '@/components/Meta'
 import { PageHeader } from '@/components/PageHeader'
 import { PageMain } from '@/components/PageMain'
 import { StakingTable } from '@/components/StakingTable'
 import { ValidatorTable } from '@/components/ValidatorTable'
-import { StakerValidatorData } from '@/interfaces/staking'
 
 export const Route = createFileRoute('/')({
   beforeLoad: () => {
@@ -41,14 +39,7 @@ function Dashboard() {
 
   const { activeAddress } = useWallet()
 
-  const stakesQuery = useQuery<StakerValidatorData[]>({
-    queryKey: ['stakes', { staker: activeAddress! }],
-    queryFn: () => fetchStakerValidatorData(activeAddress!),
-    enabled: !!activeAddress,
-    retry: false,
-    refetchInterval: 1000 * 60, // every minute
-  })
-
+  const stakesQuery = useQuery(stakesQueryOptions(activeAddress))
   const stakesByValidator = stakesQuery.data || []
 
   return (

--- a/ui/src/routes/validators_.$validatorId.tsx
+++ b/ui/src/routes/validators_.$validatorId.tsx
@@ -1,14 +1,13 @@
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query'
 import { ErrorComponent, createFileRoute } from '@tanstack/react-router'
 import { useWallet } from '@txnlab/use-wallet-react'
-import { ValidatorNotFoundError, fetchStakerValidatorData } from '@/api/contracts'
-import { constraintsQueryOptions, validatorQueryOptions } from '@/api/queries'
+import { ValidatorNotFoundError } from '@/api/contracts'
+import { constraintsQueryOptions, stakesQueryOptions, validatorQueryOptions } from '@/api/queries'
 import { Loading } from '@/components/Loading'
 import { Meta } from '@/components/Meta'
 import { PageMain } from '@/components/PageMain'
 import { ValidatorDetails } from '@/components/ValidatorDetails'
 import { DetailsHeader } from '@/components/ValidatorDetails/DetailsHeader'
-import { StakerValidatorData } from '@/interfaces/staking'
 
 export const Route = createFileRoute('/validators/$validatorId')({
   beforeLoad: () => {
@@ -44,14 +43,7 @@ function Dashboard() {
 
   const { activeAddress } = useWallet()
 
-  const stakesQuery = useQuery<StakerValidatorData[]>({
-    queryKey: ['stakes', { staker: activeAddress! }],
-    queryFn: () => fetchStakerValidatorData(activeAddress!),
-    enabled: !!activeAddress,
-    retry: false,
-    refetchInterval: 1000 * 60, // every minute
-  })
-
+  const stakesQuery = useQuery(stakesQueryOptions(activeAddress))
   const stakesByValidator = stakesQuery.data || []
 
   const pageTitle = validator.nfd ? validator.nfd.name : `Validator ${validator.id}`

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -765,10 +765,6 @@ export function calculateMaxAvailableToStake(validator: Validator, constraints?:
     maxAlgoPerPool = constraints.maxAlgoPerPool
   }
 
-  if (validator.pools.length === 0) {
-    return Number(maxAlgoPerPool)
-  }
-
   // For each pool, subtract the totalAlgoStaked from maxAlgoPerPool and return the highest value
   const maxAvailableToStake = validator.pools.reduce((acc, pool) => {
     const availableToStake = Number(maxAlgoPerPool) - Number(pool.totalAlgoStaked)

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -1,4 +1,5 @@
 import { AlgoAmount } from '@algorandfoundation/algokit-utils/types/amount'
+import { QueryClient } from '@tanstack/react-query'
 import algosdk from 'algosdk'
 import { z } from 'zod'
 import { getAccountInformation } from '@/api/algod'
@@ -817,4 +818,33 @@ export function calculateRewardEligibility(
 
   // Round down to nearest integer
   return Math.floor(eligibilityPercent)
+}
+
+/**
+ * Update validator data in the query cache after a mutation
+ * @param {QueryClient} queryClient - Tanstack Query client instance
+ * @param {Validator} data - The new validator object
+ */
+export function setValidatorQueriesData(queryClient: QueryClient, data: Validator): void {
+  const { id, nodePoolAssignment, pools } = data
+
+  queryClient.setQueryData<Validator[]>(['validators'], (prevData) => {
+    if (!prevData) {
+      return prevData
+    }
+
+    return prevData.map((validator: Validator) => {
+      if (validator.id === validator!.id) {
+        return data
+      }
+      return validator
+    })
+  })
+
+  queryClient.setQueryData<Validator>(['validator', String(id)], data)
+  queryClient.setQueryData<PoolInfo[]>(['validator-pools', String(id)], pools)
+  queryClient.setQueryData<NodePoolAssignmentConfig>(
+    ['pool-assignments', String(id)],
+    nodePoolAssignment,
+  )
 }

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -838,7 +838,7 @@ export function setValidatorQueriesData(queryClient: QueryClient, data: Validato
   })
 
   queryClient.setQueryData<Validator>(['validator', String(id)], data)
-  queryClient.setQueryData<PoolInfo[]>(['validator-pools', String(id)], pools)
+  queryClient.setQueryData<PoolInfo[]>(['pools-info', String(id)], pools)
   queryClient.setQueryData<NodePoolAssignmentConfig>(
     ['pool-assignments', String(id)],
     nodePoolAssignment,


### PR DESCRIPTION
Manual updates to the `'validators'` query cache are complex, prone to error, and brittle. Refetching the validator after a mutation (e.g., adding a new pool or staking/unstaking) and updating just that validator in the collection with real data is a better solution in every way. The only cost is a single extra network request.

This fixes a bug where `validator.pools` was not being updated after adding a pool or staking/unstaking.
