### PR TITLE
fix(ui): all gating types correctly check for valid gating asset

### DIFF
--- a/ui/src/api/nfd.ts
+++ b/ui/src/api/nfd.ts
@@ -12,7 +12,7 @@ export async function fetchNfd(
     params: { ...params, ...options?.params },
   })
 
-  if (!nfd || !nfd.appID || !nfd.name) {
+  if (!nfd || !nfd.name) {
     throw new Error('NFD not found')
   }
 

--- a/ui/src/api/nfd.ts
+++ b/ui/src/api/nfd.ts
@@ -1,11 +1,11 @@
-import { AxiosRequestConfig } from 'axios'
+import { CacheRequestConfig } from 'axios-cache-interceptor'
 import { Nfd, NfdGetNFDParams, NfdSearchV2Params, NfdV2SearchRecords } from '@/interfaces/nfd'
 import axios from '@/lib/axios'
 
 export async function fetchNfd(
   nameOrID: string | number,
   params?: NfdGetNFDParams,
-  options?: AxiosRequestConfig,
+  options?: CacheRequestConfig,
 ): Promise<Nfd> {
   const { data: nfd } = await axios.get<Nfd>(`/nfd/${nameOrID}`, {
     ...options,
@@ -21,7 +21,7 @@ export async function fetchNfd(
 
 export async function fetchNfdSearch(
   params: NfdSearchV2Params,
-  options?: AxiosRequestConfig,
+  options?: CacheRequestConfig,
 ): Promise<NfdV2SearchRecords> {
   const { data: result } = await axios.get<NfdV2SearchRecords>(`/nfd/v2/search`, {
     ...options,

--- a/ui/src/api/queries.ts
+++ b/ui/src/api/queries.ts
@@ -1,4 +1,5 @@
 import { queryOptions } from '@tanstack/react-query'
+import { CacheRequestConfig } from 'axios-cache-interceptor'
 import { fetchAssetHoldings, fetchBalance, fetchBlockTimes } from '@/api/algod'
 import {
   fetchMbrAmounts,
@@ -66,10 +67,11 @@ export const assetHoldingQueryOptions = (address: string | null) =>
 export const nfdQueryOptions = (
   nameOrId: string | number,
   params: NfdGetNFDParams = { view: 'brief' },
+  options: CacheRequestConfig = {},
 ) =>
   queryOptions({
     queryKey: ['nfd', String(nameOrId), params],
-    queryFn: () => fetchNfd(String(nameOrId), params),
+    queryFn: () => fetchNfd(String(nameOrId), params, options),
     enabled: !!nameOrId,
   })
 

--- a/ui/src/components/ValidatorDetails/EditCommissionAccount.tsx
+++ b/ui/src/components/ValidatorDetails/EditCommissionAccount.tsx
@@ -142,7 +142,7 @@ export function EditCommissionAccount({ validator }: EditCommissionAccountProps)
               )}
             />
           </div>
-          <DialogFooter className="mt-4 gap-y-2">
+          <DialogFooter className="mt-4">
             <Button
               variant="outline"
               onClick={(e) => {

--- a/ui/src/components/ValidatorDetails/EditEntryGating.tsx
+++ b/ui/src/components/ValidatorDetails/EditEntryGating.tsx
@@ -575,7 +575,7 @@ export function EditEntryGating({ validator }: EditEntryGatingProps) {
               )}
             />
           </div>
-          <DialogFooter className="mt-4 gap-y-2">
+          <DialogFooter className="mt-4">
             <Button
               variant="outline"
               onClick={(e) => {

--- a/ui/src/components/ValidatorDetails/EditManagerAccount.tsx
+++ b/ui/src/components/ValidatorDetails/EditManagerAccount.tsx
@@ -134,7 +134,7 @@ export function EditManagerAccount({ validator }: EditManagerAccountProps) {
               )}
             />
           </div>
-          <DialogFooter className="mt-4 gap-y-2">
+          <DialogFooter className="mt-4">
             <Button
               variant="outline"
               onClick={(e) => {

--- a/ui/src/components/ValidatorDetails/EditNfdForInfo.tsx
+++ b/ui/src/components/ValidatorDetails/EditNfdForInfo.tsx
@@ -281,7 +281,7 @@ export function EditNfdForInfo({ validator }: EditNfdForInfoProps) {
               )}
             />
           </div>
-          <DialogFooter className="mt-4 gap-y-2">
+          <DialogFooter className="mt-4">
             <Button
               variant="outline"
               onClick={(e) => {

--- a/ui/src/components/ValidatorDetails/EditRewardPerPayout.tsx
+++ b/ui/src/components/ValidatorDetails/EditRewardPerPayout.tsx
@@ -142,7 +142,7 @@ export function EditRewardPerPayout({ validator }: EditRewardPerPayoutProps) {
               )}
             />
           </div>
-          <DialogFooter className="mt-4 gap-y-2">
+          <DialogFooter className="mt-4">
             <Button
               variant="outline"
               onClick={(e) => {

--- a/ui/src/components/ValidatorDetails/EditSunsettingInfo.tsx
+++ b/ui/src/components/ValidatorDetails/EditSunsettingInfo.tsx
@@ -236,7 +236,7 @@ export function EditSunsettingInfo({ validator }: EditSunsettingInfoProps) {
               />
             </div>
           </div>
-          <DialogFooter className="mt-4 gap-y-2">
+          <DialogFooter className="mt-4">
             <Button
               variant="outline"
               onClick={(e) => {

--- a/ui/src/components/ui/dialog.tsx
+++ b/ui/src/components/ui/dialog.tsx
@@ -58,7 +58,7 @@ DialogHeader.displayName = 'DialogHeader'
 
 const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
+    className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
     {...props}
   />
 )

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -380,7 +380,7 @@ export async function fetchValueToVerify(
       }
 
       try {
-        const result = await fetchNfdSearch(params)
+        const result = await fetchNfdSearch(params, { cache: false })
 
         if (result.nfds.length === 0) {
           return 0

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -320,15 +320,17 @@ export function canManageValidator(activeAddress: string | null, validator: Vali
   return owner === activeAddress || manager === activeAddress
 }
 
-export async function fetchGatingAssets(
+export async function fetchValueToVerify(
   validator: Validator | null,
   activeAddress: string | null,
-): Promise<number[]> {
+  heldAssets: AssetHolding[],
+): Promise<number> {
   if (!validator || !activeAddress) {
-    return []
+    throw new Error('Validator or active address not found')
   }
 
   const { entryGatingType, entryGatingAddress, entryGatingAssets } = validator.config
+  const minBalance = Number(validator.config.gatingAssetMinBalance)
 
   if (entryGatingType === GatingType.CreatorAccount) {
     const creatorAddress = entryGatingAddress
@@ -336,12 +338,13 @@ export async function fetchGatingAssets(
 
     if (accountInfo['created-assets']) {
       const assetIds = accountInfo['created-assets'].map((asset) => asset.index)
-      return assetIds
+      return findValueToVerify(heldAssets, assetIds, minBalance)
     }
   }
 
   if (entryGatingType === GatingType.AssetId) {
-    return entryGatingAssets.filter((asset) => asset !== 0)
+    const assetIds = entryGatingAssets.filter((asset) => asset !== 0)
+    return findValueToVerify(heldAssets, assetIds, minBalance)
   }
 
   if (entryGatingType === GatingType.CreatorNfd) {
@@ -357,7 +360,7 @@ export async function fetchGatingAssets(
       .filter((asset) => !!asset)
       .map((asset) => asset!.index)
 
-    return assetIds
+    return findValueToVerify(heldAssets, assetIds, minBalance)
   }
 
   if (entryGatingType === GatingType.SegmentNfd) {
@@ -366,8 +369,6 @@ export async function fetchGatingAssets(
     let offset = 0
     const limit = 20
     let hasMoreRecords = true
-
-    const assetIds: number[] = []
 
     while (hasMoreRecords) {
       const params: NfdSearchV2Params = {
@@ -381,8 +382,17 @@ export async function fetchGatingAssets(
       try {
         const result = await fetchNfdSearch(params)
 
-        const ids = result.nfds.map((nfd) => nfd.asaID!)
-        assetIds.push(...ids)
+        if (result.nfds.length === 0) {
+          return 0
+        }
+
+        const nfdSegment = result.nfds.find((nfd) =>
+          heldAssets.some((asset) => asset['asset-id'] === nfd.asaID),
+        )
+
+        if (nfdSegment) {
+          return nfdSegment.appID || 0
+        }
 
         if (result.nfds.length < limit) {
           hasMoreRecords = false
@@ -395,27 +405,13 @@ export async function fetchGatingAssets(
       }
     }
 
-    return assetIds
+    return 0
   }
 
-  return []
+  return 0
 }
 
-export function hasQualifiedGatingAsset(
-  heldAssets: AssetHolding[],
-  gatingAssets: number[],
-  minBalance: number,
-): boolean {
-  if (gatingAssets.length == 0) {
-    return true
-  }
-
-  return heldAssets.some(
-    (asset) => gatingAssets.includes(asset['asset-id']) && asset.amount >= minBalance,
-  )
-}
-
-export function findQualifiedGatingAssetId(
+export function findValueToVerify(
   heldAssets: AssetHolding[],
   gatingAssets: number[],
   minBalance: number,


### PR DESCRIPTION
There was an issue with the way segment gating assets were being checked, and the `AddStakeModal` was showing the add stake form even if the staker did not hold a valid segment.

This refactors the logic for whether to show the "Gating Asset Required" message in the modal, and also for determining the `valueToVerify` that is passed with the `addStake` contract call.

### Issues
While this does fix things from the UI side, when attempting to add stake while holding a valid segment, the `addStake` call is still rejected despite passing the held segment's app ID as the `valueToVerify`. The error seems to correspond to this assertion in the contract: https://github.com/TxnLab/reti/blob/dev/contracts/contracts/validatorRegistry.algo.ts#L1350