### PR TITLE
fix(ui): fix calculation of rewards eligibility

### DIFF
--- a/ui/src/utils/contracts.spec.ts
+++ b/ui/src/utils/contracts.spec.ts
@@ -261,10 +261,10 @@ describe('calculateRewardEligibility', () => {
     expect(calculateRewardEligibility(10, 1000, undefined)).toBeNull()
   })
 
-  it('should calculate correct percentage when entry round and payout are in the past', () => {
+  it('should calculate correct percentage when entry round is halfway through an epoch', () => {
     const epochRoundLength = 100
     const lastPoolPayoutRound = 900
-    const entryRound = 850
+    const entryRound = 950
     expect(calculateRewardEligibility(epochRoundLength, lastPoolPayoutRound, entryRound)).toBe(50)
   })
 
@@ -290,23 +290,23 @@ describe('calculateRewardEligibility', () => {
   })
 
   it('should round down to the nearest integer', () => {
-    const epochRoundLength = 100
-    const lastPoolPayoutRound = 300
-    const entryRound = 251 // Exact eligibility is 49%
-    expect(calculateRewardEligibility(epochRoundLength, lastPoolPayoutRound, entryRound)).toBe(49)
+    const epochRoundLength = 200
+    const lastPoolPayoutRound = 600
+    const entryRound = 651 // Exact eligibility is 74.5%
+    expect(calculateRewardEligibility(epochRoundLength, lastPoolPayoutRound, entryRound)).toBe(74)
   })
 
   it('should never return more than 100%', () => {
     const epochRoundLength = 100
     const lastPoolPayoutRound = 300
-    const entryRound = 200
+    const entryRound = 200 // Calculated eligibility is 200%
     expect(calculateRewardEligibility(epochRoundLength, lastPoolPayoutRound, entryRound)).toBe(100)
   })
 
   it('should never return less than 0%', () => {
     const epochRoundLength = 100
     const lastPoolPayoutRound = 100
-    const entryRound = 200 // Future round beyond the current epoch
+    const entryRound = 250 // Future round beyond the current epoch
     expect(calculateRewardEligibility(epochRoundLength, lastPoolPayoutRound, entryRound)).toBe(0)
   })
 })

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -596,11 +596,11 @@ export function calculateRewardEligibility(
     return 0
   }
 
-  // Calculate the effective rounds staked within the current epoch starting from the last payout
-  const roundsInEpoch = Math.max(0, lastPoolPayoutRound - entryRound)
+  // Calculate the effective rounds remaining in the current epoch
+  const remainingRoundsInEpoch = Math.max(0, nextPayoutRound - entryRound)
 
   // Calculate eligibility as a percentage of the epoch length
-  const eligibilePercent = (roundsInEpoch / epochRoundLength) * 100
+  const eligibilePercent = (remainingRoundsInEpoch / epochRoundLength) * 100
 
   // Ensure eligibility is within 0-100% range
   const rewardEligibility = Math.max(0, Math.min(eligibilePercent, 100))


### PR DESCRIPTION
Instead of measuring the time remaining in the epoch to determine rewards eligibility, the time before entering the epoch was being used.

This fixes the bug and updates its tests.