### PR TITLE
fix(ui): invalidate 'pools-info' query after adding or removing stake

### DIFF
--- a/ui/src/components/AddStakeModal.tsx
+++ b/ui/src/components/AddStakeModal.tsx
@@ -321,6 +321,7 @@ export function AddStakeModal({
       // Invalidate other queries to update UI
       queryClient.invalidateQueries({ queryKey: ['stakes', { staker: activeAddress }] })
       queryClient.invalidateQueries({ queryKey: ['staked-info'] })
+      queryClient.invalidateQueries({ queryKey: ['pools-info'] })
       router.invalidate()
     } catch (error) {
       toast.error('Failed to add stake to pool', { id: toastId })

--- a/ui/src/components/UnstakeModal.tsx
+++ b/ui/src/components/UnstakeModal.tsx
@@ -216,6 +216,7 @@ export function UnstakeModal({ validator, setValidator, stakesByValidator }: Uns
       // Invalidate other queries to update UI
       queryClient.invalidateQueries({ queryKey: ['stakes', { staker: activeAddress }] })
       queryClient.invalidateQueries({ queryKey: ['staked-info'] })
+      queryClient.invalidateQueries({ queryKey: ['pools-info'] })
       router.invalidate()
     } catch (error) {
       toast.error('Failed to remove stake from pool', { id: toastId })


### PR DESCRIPTION
When adding or removing stake from the `StakingDetails` component (on the validator details page), the progress bar showing current stake in proportion to max stake does not update. Its query is not among the ones being invalidated on success.

This invalidates the query after a mutation that changes the total amount staked in a pool.