### PR TITLE
fix(ui): token payout ratios are not needed/used in the UI

### DIFF
--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -24,7 +24,6 @@ import {
   RawConstraints,
   RawNodePoolAssignmentConfig,
   RawPoolsInfo,
-  RawPoolTokenPayoutRatios,
   RawValidatorConfig,
   RawValidatorState,
   Validator,
@@ -85,28 +84,19 @@ export async function fetchValidator(
   try {
     const validatorClient = client || (await getSimulateValidatorClient())
 
-    const [config, state, validatorPoolData, poolTokenPayoutRatios, nodePoolAssignments] =
-      await Promise.all([
-        callGetValidatorConfig(Number(validatorId), validatorClient),
-        callGetValidatorState(Number(validatorId), validatorClient),
-        callGetPools(Number(validatorId), validatorClient),
-        callGetTokenPayoutRatio(Number(validatorId), validatorClient),
-        callGetNodePoolAssignments(Number(validatorId), validatorClient),
-      ])
+    const [config, state, validatorPoolData, nodePoolAssignments] = await Promise.all([
+      callGetValidatorConfig(Number(validatorId), validatorClient),
+      callGetValidatorState(Number(validatorId), validatorClient),
+      callGetPools(Number(validatorId), validatorClient),
+      callGetNodePoolAssignments(Number(validatorId), validatorClient),
+    ])
 
     const rawConfig = config.returns?.[0] as RawValidatorConfig
     const rawState = state.returns?.[0] as RawValidatorState
     const rawPoolsInfo = validatorPoolData.returns?.[0] as RawPoolsInfo
-    const rawPoolTokenPayoutRatios = poolTokenPayoutRatios.returns?.[0] as RawPoolTokenPayoutRatios
     const rawNodePoolAssignment = nodePoolAssignments.returns?.[0] as RawNodePoolAssignmentConfig
 
-    if (
-      !rawConfig ||
-      !rawState ||
-      !rawPoolsInfo ||
-      !rawPoolTokenPayoutRatios ||
-      !rawNodePoolAssignment
-    ) {
+    if (!rawConfig || !rawState || !rawPoolsInfo || !rawNodePoolAssignment) {
       throw new ValidatorNotFoundError(`Validator with id "${Number(validatorId)}" not found!`)
     }
 
@@ -115,7 +105,6 @@ export async function fetchValidator(
       rawConfig,
       rawState,
       rawPoolsInfo,
-      rawPoolTokenPayoutRatios,
       rawNodePoolAssignment,
     )
 
@@ -312,29 +301,6 @@ export async function fetchNodePoolAssignments(
 
     const nodePoolAssignmentConfig = transformNodePoolAssignment(rawNodePoolAssignmentConfig)
     return nodePoolAssignmentConfig
-  } catch (error) {
-    console.error(error)
-    throw error
-  }
-}
-
-export function callGetTokenPayoutRatio(
-  validatorId: number | bigint,
-  validatorClient: ValidatorRegistryClient,
-) {
-  return validatorClient
-    .compose()
-    .getTokenPayoutRatio({ validatorId })
-    .simulate({ allowEmptySignatures: true, allowUnnamedResources: true })
-}
-
-export async function fetchTokenPayoutRatio(validatorId: string | number | bigint) {
-  try {
-    const validatorClient = await getSimulateValidatorClient()
-
-    const result = await callGetTokenPayoutRatio(Number(validatorId), validatorClient)
-
-    return result.returns![0]
   } catch (error) {
     console.error(error)
     throw error

--- a/ui/src/interfaces/validator.ts
+++ b/ui/src/interfaces/validator.ts
@@ -69,13 +69,6 @@ export interface PoolInfo {
   algodVersion?: string
 }
 
-export type RawPoolTokenPayoutRatios = [[bigint, ...bigint[]], bigint]
-
-export interface PoolTokenPayoutRatio {
-  poolPctOfWhole: number[]
-  updatedForPayout: number
-}
-
 export type NodeConfig = [bigint, ...bigint[]]
 export type RawNodePoolAssignmentConfig = [[NodeConfig][]]
 export type NodePoolAssignmentConfig = NodeConfig[]
@@ -90,7 +83,6 @@ export type Validator = {
   config: Omit<ValidatorConfig, 'id'>
   state: ValidatorState
   pools: PoolInfo[]
-  tokenPayoutRatio: number[]
   nodePoolAssignment: NodePoolAssignmentConfig
   nfd?: Nfd
 }

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -12,10 +12,8 @@ import {
   NodeInfo,
   NodePoolAssignmentConfig,
   PoolInfo,
-  PoolTokenPayoutRatio,
   RawNodePoolAssignmentConfig,
   RawPoolsInfo,
-  RawPoolTokenPayoutRatios,
   RawValidatorConfig,
   RawValidatorState,
   Validator,
@@ -91,27 +89,10 @@ export function transformNodePoolAssignment(
 }
 
 /**
- * Transform raw pool token payout ratio data (from `callGetTokenPayoutRatio`) into a flat array of payout ratios
- * @param {RawPoolTokenPayoutRatios} rawData - Raw pool token payout ratio data
- * @returns {number[]} Array of pool token payout ratios
- */
-export function transformPoolTokenPayoutRatio(rawData: RawPoolTokenPayoutRatios): number[] {
-  const [poolPctOfWhole, updatedForPayout] = rawData
-
-  const poolTokenPayoutRatio: PoolTokenPayoutRatio = {
-    poolPctOfWhole: poolPctOfWhole.map((poolPct) => Number(poolPct)),
-    updatedForPayout: Number(updatedForPayout),
-  }
-
-  return poolTokenPayoutRatio.poolPctOfWhole
-}
-
-/**
  * Transform raw validator data from multiple ABI method calls into a structured `Validator` object
  * @param {RawValidatorConfig} rawConfig - Raw validator configuration data
  * @param {RawValidatorState} rawState - Raw validator state data
  * @param {RawPoolsInfo} rawPoolsInfo - Raw staking pool data
- * @param {RawPoolTokenPayoutRatios} rawPoolTokenPayoutRatios - Raw pool token payout ratio data
  * @param {RawNodePoolAssignmentConfig} rawNodePoolAssignment - Raw node pool assignment configuration data
  * @returns {Validator} Structured validator object
  */
@@ -119,13 +100,11 @@ export function transformValidatorData(
   rawConfig: RawValidatorConfig,
   rawState: RawValidatorState,
   rawPoolsInfo: RawPoolsInfo,
-  rawPoolTokenPayoutRatios: RawPoolTokenPayoutRatios,
   rawNodePoolAssignment: RawNodePoolAssignmentConfig,
 ): Validator {
   const { id, ...config } = transformValidatorConfig(rawConfig)
   const state = transformValidatorState(rawState)
   const pools = transformPoolsInfo(rawPoolsInfo)
-  const tokenPayoutRatio = transformPoolTokenPayoutRatio(rawPoolTokenPayoutRatios)
   const nodePoolAssignment = transformNodePoolAssignment(rawNodePoolAssignment)
 
   return {
@@ -133,7 +112,6 @@ export function transformValidatorData(
     config,
     state,
     pools,
-    tokenPayoutRatio,
     nodePoolAssignment,
   }
 }

--- a/ui/src/utils/tests/fixtures/validators.ts
+++ b/ui/src/utils/tests/fixtures/validators.ts
@@ -114,8 +114,6 @@ export const MOCK_VALIDATOR_2_POOL_ASSIGNMENT: NodeConfig[] = createStaticArray<
   8,
 )
 
-export const MOCK_TOKEN_PAYOUT_RATIO = new Array(24).fill(0)
-
 const { id: validator1Id, ...validator1Config } = MOCK_VALIDATOR_1_CONFIG
 
 export const MOCK_VALIDATOR_1: Validator = {
@@ -123,7 +121,6 @@ export const MOCK_VALIDATOR_1: Validator = {
   config: validator1Config,
   state: MOCK_VALIDATOR_1_STATE,
   pools: MOCK_VALIDATOR_1_POOLS,
-  tokenPayoutRatio: MOCK_TOKEN_PAYOUT_RATIO,
   nodePoolAssignment: MOCK_VALIDATOR_1_POOL_ASSIGNMENT,
 }
 
@@ -134,7 +131,6 @@ export const MOCK_VALIDATOR_2: Validator = {
   config: validator2Config,
   state: MOCK_VALIDATOR_2_STATE,
   pools: MOCK_VALIDATOR_2_POOLS,
-  tokenPayoutRatio: MOCK_TOKEN_PAYOUT_RATIO,
   nodePoolAssignment: MOCK_VALIDATOR_2_POOL_ASSIGNMENT,
 }
 


### PR DESCRIPTION
This removes fetches for token payout ratios for each validator, as they are only needed internally and for testing. 

This will save lots of unnecessary simulate calls as this was being fetched (and refetched) for every validator in the dashboard.