### PR TITLE
feat(ui): reward token improvements

### DIFF
--- a/ui/src/api/algod.ts
+++ b/ui/src/api/algod.ts
@@ -38,8 +38,17 @@ export async function fetchAccountBalance(
 }
 
 export async function fetchAsset(assetId: number): Promise<Asset> {
-  const asset = await algodClient.getAssetByID(assetId).do()
-  return asset as Asset
+  try {
+    const asset = await algodClient.getAssetByID(assetId).do()
+    return asset as Asset
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    if (error.message && error.response) {
+      throw new AlgodHttpError(error.message, error.response)
+    } else {
+      throw error
+    }
+  }
 }
 
 export async function fetchBalance(address: string | null): Promise<AccountBalance> {

--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -2,7 +2,7 @@ import * as algokit from '@algorandfoundation/algokit-utils'
 import { TransactionSignerAccount } from '@algorandfoundation/algokit-utils/types/account'
 import { AlgoAmount } from '@algorandfoundation/algokit-utils/types/amount'
 import algosdk from 'algosdk'
-import { isOptedInToAsset } from '@/api/algod'
+import { fetchAsset, isOptedInToAsset } from '@/api/algod'
 import {
   getSimulateStakingPoolClient,
   getSimulateValidatorClient,
@@ -107,6 +107,11 @@ export async function fetchValidator(
       rawPoolsInfo,
       rawNodePoolAssignment,
     )
+
+    if (validator.config.rewardTokenId > 0) {
+      const rewardToken = await fetchAsset(validator.config.rewardTokenId)
+      validator.rewardToken = rewardToken
+    }
 
     if (validator.config.nfdForInfo > 0) {
       const nfd = await fetchNfd(validator.config.nfdForInfo, { view: 'full' })

--- a/ui/src/components/AddValidatorForm.tsx
+++ b/ui/src/components/AddValidatorForm.tsx
@@ -12,6 +12,7 @@ import { z } from 'zod'
 import { addValidator, fetchValidator } from '@/api/contracts'
 import { fetchNfd } from '@/api/nfd'
 import { AlgoSymbol } from '@/components/AlgoSymbol'
+import { AssetLookup } from '@/components/AssetLookup'
 import { InfoPopover } from '@/components/InfoPopover'
 import { Button } from '@/components/ui/button'
 import {
@@ -35,6 +36,7 @@ import {
 import { Separator } from '@/components/ui/separator'
 import { GatingType } from '@/constants/gating'
 import { useBlockTime } from '@/hooks/useBlockTime'
+import { Asset } from '@/interfaces/algod'
 import { Constraints } from '@/interfaces/validator'
 import { useAuthAddress } from '@/providers/AuthAddressProvider'
 import {
@@ -61,6 +63,8 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
   const [isFetchingNfdCreator, setIsFetchingNfdCreator] = React.useState(false)
   const [nfdParentAppId, setNfdParentAppId] = React.useState<number>(0)
   const [isFetchingNfdParent, setIsFetchingNfdParent] = React.useState(false)
+  const [rewardToken, setRewardToken] = React.useState<Asset | null>(null)
+  const [isFetchingRewardToken, setIsFetchingRewardToken] = React.useState(false)
   const [epochTimeframe, setEpochTimeframe] = React.useState('blocks')
   const [isSigning, setIsSigning] = React.useState(false)
 
@@ -122,6 +126,9 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
     control: form.control,
     name: 'entryGatingAssets',
   })
+
+  const $rewardTokenId = form.watch('rewardTokenId')
+  const isRewardTokenInvalid = Number($rewardTokenId) > 0 && (isFetchingRewardToken || !rewardToken)
 
   const $entryGatingType = form.watch('entryGatingType')
 
@@ -672,18 +679,15 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
               <p className="sm:col-span-2 text-sm text-muted-foreground">
                 Reward token to be paid out to stakers (optional)
               </p>
-              <FormField
-                control={form.control}
+              <AssetLookup
+                form={form}
                 name="rewardTokenId"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Asset ID</FormLabel>
-                    <FormControl>
-                      <Input placeholder="" autoComplete="new-password" {...field} />
-                    </FormControl>
-                    <FormMessage>{errors.rewardTokenId?.message}</FormMessage>
-                  </FormItem>
-                )}
+                label="Asset ID"
+                asset={rewardToken}
+                setAsset={setRewardToken}
+                isFetching={isFetchingRewardToken}
+                setIsFetching={setIsFetchingRewardToken}
+                errorMessage={errors.rewardTokenId?.message}
               />
 
               <FormField
@@ -1098,7 +1102,11 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
               size="lg"
               className="w-full text-base sm:w-auto"
               disabled={
-                isSigning || isFetchingNfdForInfo || isFetchingNfdCreator || isFetchingNfdParent
+                isSigning ||
+                isRewardTokenInvalid ||
+                isFetchingNfdForInfo ||
+                isFetchingNfdCreator ||
+                isFetchingNfdParent
               }
             >
               <Monitor className="mr-2 h-5 w-5" />

--- a/ui/src/components/AddValidatorForm.tsx
+++ b/ui/src/components/AddValidatorForm.tsx
@@ -48,7 +48,7 @@ import {
 import { getNfdAppFromViteEnvironment } from '@/utils/network/getNfdConfig'
 import { isValidName, trimExtension } from '@/utils/nfd'
 import { cn } from '@/utils/ui'
-import { entryGatingRefinement, validatorSchemas } from '@/utils/validation'
+import { entryGatingRefinement, rewardTokenRefinement, validatorSchemas } from '@/utils/validation'
 
 const nfdAppUrl = getNfdAppFromViteEnvironment()
 
@@ -94,6 +94,7 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
       minEntryStake: validatorSchemas.minEntryStake(constraints),
       poolsPerNode: validatorSchemas.poolsPerNode(constraints),
     })
+    .superRefine((data, ctx) => rewardTokenRefinement(data, ctx))
     .superRefine((data, ctx) => entryGatingRefinement(data, ctx))
 
   type FormValues = z.infer<typeof formSchema>

--- a/ui/src/components/AddValidatorForm.tsx
+++ b/ui/src/components/AddValidatorForm.tsx
@@ -45,6 +45,7 @@ import {
   transformEntryGatingAssets,
 } from '@/utils/contracts'
 // import { validatorAutoFill } from '@/utils/development'
+import { convertToBaseUnits } from '@/utils/format'
 import { getNfdAppFromViteEnvironment } from '@/utils/network/getNfdConfig'
 import { isValidName, trimExtension } from '@/utils/nfd'
 import { cn } from '@/utils/ui'
@@ -94,7 +95,7 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
       minEntryStake: validatorSchemas.minEntryStake(constraints),
       poolsPerNode: validatorSchemas.poolsPerNode(constraints),
     })
-    .superRefine((data, ctx) => rewardTokenRefinement(data, ctx))
+    .superRefine((data, ctx) => rewardTokenRefinement(data, ctx, rewardToken?.params.decimals))
     .superRefine((data, ctx) => entryGatingRefinement(data, ctx))
 
   type FormValues = z.infer<typeof formSchema>
@@ -250,6 +251,11 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
 
       toast.loading('Sign transactions to add validator...', { id: toastId })
 
+      const rewardPerPayout = convertToBaseUnits(
+        Number(values.rewardPerPayout),
+        Number(rewardToken?.params.decimals || 0),
+      )
+
       const epochRoundLength = getEpochLengthBlocks(
         values.epochRoundLength,
         epochTimeframe,
@@ -265,6 +271,7 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
 
       const newValues = {
         ...values,
+        rewardPerPayout: String(rewardPerPayout),
         epochRoundLength: String(epochRoundLength),
         entryGatingAssets,
       }

--- a/ui/src/components/AssetLookup.tsx
+++ b/ui/src/components/AssetLookup.tsx
@@ -1,0 +1,144 @@
+import { Check } from 'lucide-react'
+import { FieldPath, FieldValues, UseFormReturn } from 'react-hook-form'
+import { useDebouncedCallback } from 'use-debounce'
+import { fetchAsset as fetchAssetInformation } from '@/api/algod'
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { AlgodHttpError, Asset } from '@/interfaces/algod'
+import { cn } from '@/utils/ui'
+
+const ERROR_NOT_FOUND = 'Asset not found'
+const ERROR_FAILED = 'Failed to fetch asset'
+const ERROR_UNKNOWN = 'An unknown error occurred'
+
+interface AssetLookupProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> {
+  form: UseFormReturn<TFieldValues>
+  name: TName
+  asset: Asset | null
+  setAsset: (asset: Asset | null) => void
+  isFetching: boolean
+  setIsFetching: (isFetching: boolean) => void
+  errorMessage?: string
+  label?: string
+  className?: string
+}
+
+export function AssetLookup<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  form,
+  name,
+  asset,
+  setAsset,
+  isFetching,
+  setIsFetching,
+  errorMessage,
+  label,
+  className = '',
+}: AssetLookupProps<TFieldValues, TName>) {
+  const fetchAsset = async (value: string) => {
+    try {
+      const asset = await fetchAssetInformation(Number(value))
+
+      form.clearErrors(name)
+      setAsset(asset)
+    } catch (error: unknown) {
+      let message: string
+      if (error instanceof AlgodHttpError && error.response) {
+        // Handle HTTP errors
+        if (error.response.status === 404) {
+          message = ERROR_NOT_FOUND
+        } else {
+          console.error(error)
+          message = ERROR_FAILED
+        }
+      } else if (error instanceof Error) {
+        // Handle non-HTTP errors
+        console.error(error)
+        message = error.message
+      } else {
+        // Handle unknown errors
+        console.error(error)
+        message = ERROR_UNKNOWN
+      }
+      form.setError(name, { type: 'manual', message })
+    } finally {
+      setIsFetching(false)
+    }
+  }
+
+  const debouncedFetchAsset = useDebouncedCallback(async (value) => {
+    const isValid = await form.trigger(name)
+    if (isValid) {
+      await fetchAsset(value)
+    } else {
+      setIsFetching(false)
+    }
+  }, 500)
+
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className={className}>
+          {label && <FormLabel>{label}</FormLabel>}
+          <div className="flex items-center gap-x-3">
+            <div className="flex-1 relative">
+              <FormControl>
+                <Input
+                  className={cn(isFetching || asset ? 'pr-28' : '')}
+                  autoComplete="new-password"
+                  spellCheck="false"
+                  {...field}
+                  onChange={(e) => {
+                    field.onChange(e) // Inform react-hook-form of the change
+                    setAsset(null) // Reset asset
+                    setIsFetching(true) // Set fetching state
+                    debouncedFetchAsset(e.target.value) // Perform debounced validation
+                  }}
+                />
+              </FormControl>
+              <div
+                className={cn(
+                  isFetching || asset ? 'opacity-100' : 'opacity-0',
+                  'pointer-events-none absolute inset-y-0 right-0 flex items-center pr-3',
+                )}
+              >
+                {isFetching ? (
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    className="h-5 w-5 animate-spin opacity-25"
+                    aria-hidden="true"
+                  >
+                    <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                  </svg>
+                ) : asset ? (
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-mono text-muted-foreground">
+                      {asset.params['unit-name']}
+                    </span>
+                    <Check className="h-5 w-5 text-green-500" />
+                  </div>
+                ) : null}
+              </div>
+            </div>
+          </div>
+          <FormMessage>{errorMessage}</FormMessage>
+        </FormItem>
+      )}
+    />
+  )
+}

--- a/ui/src/components/ValidatorDetails/Details.tsx
+++ b/ui/src/components/ValidatorDetails/Details.tsx
@@ -14,7 +14,7 @@ import { Validator } from '@/interfaces/validator'
 import { dayjs } from '@/utils/dayjs'
 import { ellipseAddressJsx } from '@/utils/ellipseAddress'
 import { ExplorerLink } from '@/utils/explorer'
-import { formatAssetAmount, formatNumber } from '@/utils/format'
+import { convertFromBaseUnits, formatAssetAmount, formatNumber } from '@/utils/format'
 import { getNfdAppFromViteEnvironment } from '@/utils/network/getNfdConfig'
 
 const nfdAppUrl = getNfdAppFromViteEnvironment()
@@ -56,6 +56,29 @@ export function Details({ validator }: DetailsProps) {
     }
 
     return validator.config.rewardTokenId
+  }
+
+  const renderRewardPerPayout = () => {
+    if (validator.config.rewardPerPayout === 0n) {
+      return <span className="text-muted-foreground">--</span>
+    }
+
+    if (!validator.rewardToken) {
+      return (
+        <em className="text-muted-foreground italic">{Number(validator.config.rewardPerPayout)}</em>
+      )
+    }
+
+    const convertedAmount = convertFromBaseUnits(
+      Number(validator.config.rewardPerPayout),
+      Number(validator.rewardToken.params.decimals),
+    )
+
+    return (
+      <span className="font-mono">
+        {formatNumber(convertedAmount)} {validator.rewardToken.params['unit-name']}
+      </span>
+    )
   }
 
   const renderEntryGating = () => {
@@ -274,11 +297,7 @@ export function Details({ validator }: DetailsProps) {
                       Reward Per Payout
                     </dt>
                     <dd className="flex items-center justify-between gap-x-2 text-sm leading-6">
-                      {Number(validator.config.rewardPerPayout) === 0 ? (
-                        <span className="text-muted-foreground">--</span>
-                      ) : (
-                        Number(validator.config.rewardPerPayout)
-                      )}
+                      {renderRewardPerPayout()}
                       {isOwner && validator.config.rewardTokenId > 0 && (
                         <EditRewardPerPayout validator={validator} />
                       )}

--- a/ui/src/components/ValidatorDetails/Details.tsx
+++ b/ui/src/components/ValidatorDetails/Details.tsx
@@ -28,6 +28,36 @@ export function Details({ validator }: DetailsProps) {
 
   const isOwner = activeAddress === validator.config.owner
 
+  const renderRewardToken = () => {
+    if (validator.config.rewardTokenId === 0) {
+      return null
+    }
+
+    const { rewardToken } = validator
+
+    if (!rewardToken) {
+      return validator.config.rewardTokenId
+    }
+
+    const { name, 'unit-name': unitName } = rewardToken.params
+
+    if (name) {
+      return unitName ? (
+        <>
+          {name} (<span className="font-mono">{unitName}</span>)
+        </>
+      ) : (
+        name
+      )
+    }
+
+    if (unitName) {
+      return <span className="font-mono">{unitName}</span>
+    }
+
+    return validator.config.rewardTokenId
+  }
+
   const renderEntryGating = () => {
     const { entryGatingType, entryGatingAddress, entryGatingAssets } = validator.config
 
@@ -228,7 +258,14 @@ export function Details({ validator }: DetailsProps) {
                       {validator.config.rewardTokenId === 0 ? (
                         <span className="text-muted-foreground">--</span>
                       ) : (
-                        validator.config.rewardTokenId
+                        <a
+                          href={ExplorerLink.asset(validator.config.rewardTokenId)}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-link"
+                        >
+                          {renderRewardToken()}
+                        </a>
                       )}
                     </dd>
                   </div>

--- a/ui/src/interfaces/validator.ts
+++ b/ui/src/interfaces/validator.ts
@@ -1,3 +1,4 @@
+import { Asset } from '@/interfaces/algod'
 import { Nfd } from '@/interfaces/nfd'
 import { ToStringTypes } from '@/interfaces/utils'
 
@@ -84,6 +85,7 @@ export type Validator = {
   state: ValidatorState
   pools: PoolInfo[]
   nodePoolAssignment: NodePoolAssignmentConfig
+  rewardToken?: Asset
   nfd?: Nfd
 }
 

--- a/ui/src/utils/format.spec.ts
+++ b/ui/src/utils/format.spec.ts
@@ -99,6 +99,11 @@ describe('formatNumber', () => {
     expect(result).toBe('12,345.68')
   })
 
+  it('should include all decimal places if precision is undefined', () => {
+    const result = formatNumber(12345.6789)
+    expect(result).toBe('12,345.6789')
+  })
+
   it('should format a number in compact notation with precision', () => {
     const result = formatNumber(1234567, { compact: true, precision: 2 })
     expect(result).toBe('1.23M')

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -210,7 +210,7 @@ export function formatNumber(
   amount: number | bigint | string,
   options: FormatNumberOptions = {},
 ): string {
-  const { compact = false, precision = 0, trim = true } = options
+  const { compact = false, precision, trim = true } = options
 
   // Handle BigInt separately to preserve precision
   if (typeof amount === 'bigint') {
@@ -221,7 +221,7 @@ export function formatNumber(
   const numericAmount = parseFloat(String(amount))
 
   if (compact) {
-    return formatWithPrecision(numericAmount, precision)
+    return formatWithPrecision(numericAmount, precision || 0)
   }
 
   const bigAmount = new Big(numericAmount).toFixed(precision)

--- a/ui/src/utils/validation.ts
+++ b/ui/src/utils/validation.ts
@@ -228,6 +228,24 @@ export const validatorSchemas = {
 }
 
 /**
+ * Validator schema refinement for reward token
+ * @param {any} data - The form data
+ * @param {RefinementCtx} ctx - The refinement context
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const rewardTokenRefinement = (data: any, ctx: RefinementCtx) => {
+  const { rewardTokenId, rewardPerPayout } = data
+
+  if (Number(rewardTokenId) > 0 && rewardPerPayout === '') {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ['rewardPerPayout'],
+      message: 'Reward per payout must be set when reward token is enabled',
+    })
+  }
+}
+
+/**
  * Validator schema refinement for entry gating
  * @param {any} data - The form data
  * @param {RefinementCtx} ctx - The refinement context

--- a/ui/src/utils/validation.ts
+++ b/ui/src/utils/validation.ts
@@ -231,10 +231,35 @@ export const validatorSchemas = {
  * Validator schema refinement for reward token
  * @param {any} data - The form data
  * @param {RefinementCtx} ctx - The refinement context
+ * @param {number | bigint} decimals - The reward token's decimals value
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const rewardTokenRefinement = (data: any, ctx: RefinementCtx) => {
+export const rewardTokenRefinement = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any,
+  ctx: RefinementCtx,
+  decimals?: number | bigint,
+) => {
   const { rewardTokenId, rewardPerPayout } = data
+
+  if (Number(rewardTokenId) > 0) {
+    if (rewardPerPayout === '') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['rewardPerPayout'],
+        message: 'Required field',
+      })
+    } else if (decimals) {
+      const regex = new RegExp(`^\\d+(\\.\\d{1,${Number(decimals)}})?$`)
+
+      if (!regex.test(rewardPerPayout)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['rewardPerPayout'],
+          message: `Cannot have more than ${decimals} decimal places`,
+        })
+      }
+    }
+  }
 
   if (Number(rewardTokenId) > 0 && rewardPerPayout === '') {
     ctx.addIssue({


### PR DESCRIPTION
This makes a number of improvements to how the UI handles reward tokens:

### Add Validator form
- fetch asset info from reward token ID (debounced), showing unit name and green check mark if it exists
- validate reward token is an actual asset, prevents form submission if not
- validate reward per payout is set if reward token is set
- reward per payout is expected in whole units, not base units

### `Validator` object
- fetches reward token's asset info and sets it to the `Validator`'s `rewardToken?: Asset` property

### Validator details page
- show reward token name/unit-name in validator details instead of ID
- reward token is a link to the asset in block explorer
- show reward per payout in whole units of asset with unit name

### Other Changes
Fixes a bug in `formatNumber` where no decimals were shown if `options.precision` was undefined. Now if precision is unset all decimals are shown.