### PR TITLE
feat(ui): update simulateEpoch to support rounds

### DIFF
--- a/ui/src/components/StakingTable.tsx
+++ b/ui/src/components/StakingTable.tsx
@@ -251,7 +251,7 @@ export function StakingTable({
                     <DropdownMenuSeparator />
                     <DropdownMenuGroup>
                       <DropdownMenuItem
-                        onClick={async () =>
+                        onClick={async () => {
                           await simulateEpoch(
                             validator,
                             row.original.pools,
@@ -262,7 +262,7 @@ export function StakingTable({
                             queryClient,
                             router,
                           )
-                        }
+                        }}
                         disabled={unstakingDisabled}
                       >
                         <FlaskConical className="h-4 w-4 mr-2 text-muted-foreground" />

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -1,5 +1,6 @@
 import { AlgoAmount } from '@algorandfoundation/algokit-utils/types/amount'
-import { Link, useNavigate } from '@tanstack/react-router'
+import { useQueryClient } from '@tanstack/react-query'
+import { Link, useNavigate, useRouter } from '@tanstack/react-router'
 import {
   ColumnDef,
   ColumnFiltersState,
@@ -47,6 +48,7 @@ import { useBlockTime } from '@/hooks/useBlockTime'
 import { useLocalStorage } from '@/hooks/useLocalStorage'
 import { StakerValidatorData } from '@/interfaces/staking'
 import { Constraints, Validator } from '@/interfaces/validator'
+import { useAuthAddress } from '@/providers/AuthAddressProvider'
 import {
   calculateMaxStake,
   calculateMaxStakers,
@@ -58,7 +60,7 @@ import {
   isUnstakingDisabled,
 } from '@/utils/contracts'
 import { dayjs, formatDuration } from '@/utils/dayjs'
-import { sendRewardTokensToPool } from '@/utils/development'
+import { sendRewardTokensToPool, simulateEpoch } from '@/utils/development'
 import { ellipseAddressJsx } from '@/utils/ellipseAddress'
 import { formatNumber } from '@/utils/format'
 import { cn } from '@/utils/ui'
@@ -82,8 +84,11 @@ export function ValidatorTable({
   const [addPoolValidator, setAddPoolValidator] = React.useState<Validator | null>(null)
 
   const { transactionSigner, activeAddress } = useWallet()
-  const navigate = useNavigate()
+  const { authAddress } = useAuthAddress()
 
+  const router = useRouter()
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
   const blockTime = useBlockTime()
 
   const [sorting, setSorting] = useLocalStorage<SortingState>('validator-sorting', [
@@ -286,6 +291,12 @@ export function ValidatorTable({
         const canSendRewardTokens = isDevelopment && canManage && hasRewardToken
         const sendRewardTokensDisabled = validator.state.numPools === 0
 
+        const stakerValidatorData = stakesByValidator.find(
+          (data) => data.validatorId === validator.id,
+        )
+        const stakerPoolData = stakerValidatorData?.pools
+        const canSimulateEpoch = isDevelopment && canManage && !!stakerPoolData
+
         return (
           <div className="flex items-center justify-end gap-x-2">
             {isSunsetting(validator) && !unstakingDisabled ? (
@@ -353,6 +364,33 @@ export function ValidatorTable({
                     >
                       Add Staking Pool
                     </DropdownMenuItem>
+                  )}
+
+                  {canSimulateEpoch && (
+                    <>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuGroup>
+                        <DropdownMenuItem
+                          onClick={async (e) => {
+                            e.stopPropagation()
+                            await simulateEpoch(
+                              validator,
+                              stakerPoolData,
+                              100,
+                              transactionSigner,
+                              activeAddress!,
+                              authAddress,
+                              queryClient,
+                              router,
+                            )
+                          }}
+                          disabled={unstakingDisabled}
+                        >
+                          <FlaskConical className="h-4 w-4 mr-2 text-muted-foreground" />
+                          Simulate Epoch
+                        </DropdownMenuItem>
+                      </DropdownMenuGroup>
+                    </>
                   )}
 
                   {canSendRewardTokens && (

--- a/ui/src/utils/development.tsx
+++ b/ui/src/utils/development.tsx
@@ -47,7 +47,7 @@ export async function incrementRoundNumberBy(rounds: number) {
     return result
   }
 
-  console.log(`Increment round number start: ${result.startRound}`)
+  // console.log(`Increment round number start: ${result.startRound}`)
 
   const testAccount = await getTestAccount(
     { initialFunds: AlgoAmount.Algos(10), suppressLog: true },
@@ -78,7 +78,7 @@ export async function incrementRoundNumberBy(rounds: number) {
     ...result,
     resultRound: resultParams.firstRound,
   }
-  console.log(`Increment round number result: ${result.resultRound}`)
+  // console.log(`Increment round number result: ${result.resultRound}`)
 
   return result
 }
@@ -195,7 +195,7 @@ export async function simulateEpoch(
         <span className="text-foreground">
           Simulated {data.rounds} rounds:{' '}
           <span className="whitespace-nowrap">
-            {data.startRound} &raquo; {data.resultRound}
+            {data.startRound} &rarr; {data.resultRound}
           </span>
         </span>
       ),

--- a/ui/src/utils/development.tsx
+++ b/ui/src/utils/development.tsx
@@ -1,4 +1,5 @@
 import * as algokit from '@algorandfoundation/algokit-utils'
+import { getTestAccount } from '@algorandfoundation/algokit-utils/testing'
 import { AlgoAmount } from '@algorandfoundation/algokit-utils/types/amount'
 import { QueryClient } from '@tanstack/react-query'
 import { useRouter } from '@tanstack/react-router'
@@ -21,6 +22,120 @@ const algodClient = algokit.getAlgoClient({
   token: algodConfig.token,
 })
 
+const kmdClient = algokit.getAlgoKmdClient({
+  server: algodConfig.server,
+  port: algodConfig.port,
+  token: algodConfig.token,
+})
+
+async function wait(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+}
+
+export async function incrementRoundNumberBy(rounds: number) {
+  const startParams = await algodClient.getTransactionParams().do()
+
+  let result = {
+    rounds,
+    startRound: startParams.firstRound,
+    resultRound: startParams.firstRound,
+  }
+
+  if (rounds === 0) {
+    return result
+  }
+
+  console.log(`Increment round number start: ${result.startRound}`)
+
+  const testAccount = await getTestAccount(
+    { initialFunds: AlgoAmount.Algos(10), suppressLog: true },
+    algodClient,
+    kmdClient,
+  )
+
+  let txnId = ''
+  for (let i = 0; i < rounds; i++) {
+    const txn = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
+      from: testAccount.addr,
+      to: testAccount.addr,
+      amount: 0,
+      note: new TextEncoder().encode(`${i}`),
+      suggestedParams: startParams,
+    })
+
+    const signedTransaction = await algokit.signTransaction(txn, testAccount)
+    const { txId } = await algodClient.sendRawTransaction(signedTransaction).do()
+    txnId = txId
+  }
+
+  await algokit.waitForConfirmation(txnId, rounds + 1, algodClient)
+
+  const resultParams = await algodClient.getTransactionParams().do()
+
+  result = {
+    ...result,
+    resultRound: resultParams.firstRound,
+  }
+  console.log(`Increment round number result: ${result.resultRound}`)
+
+  return result
+}
+
+export async function triggerPoolPayouts(
+  pools: StakerPoolData[],
+  signer: algosdk.TransactionSigner,
+  activeAddress: string,
+  authAddr: string | undefined,
+) {
+  function createNextItemPromise(): [Promise<void>, () => void] {
+    let resolveNextItem: () => void
+    const nextItemPromise = new Promise<void>((resolve) => {
+      resolveNextItem = resolve
+    })
+    return [nextItemPromise, resolveNextItem!]
+  }
+
+  for (let i = 0; i < pools.length; i++) {
+    const pool = pools[i]
+    const poolAppId = pool.poolKey.poolAppId
+    const poolId = pool.poolKey.poolId
+
+    const isLastPool = i === pools.length - 1
+
+    const promiseFunction = epochBalanceUpdate(poolAppId, signer, activeAddress, authAddr)
+
+    const [nextItemPromise, resolveNextItem] = createNextItemPromise()
+
+    toast.promise(promiseFunction, {
+      loading: `Sign for Pool ${poolId} payout`,
+      success: () =>
+        !isLastPool ? (
+          <div className="flex items-center justify-between w-full">
+            Pool {i + 1}/{pools.length} payout complete!
+            <button
+              data-button
+              className="group-[.toast]:bg-primary group-[.toast]:text-primary-foreground"
+              onClick={() => resolveNextItem()}
+            >
+              Next pool
+            </button>
+          </div>
+        ) : (
+          'Epoch balance update complete!'
+        ),
+      error: `Error triggering Pool ${poolId} payout`,
+    })
+
+    await promiseFunction
+
+    if (!isLastPool) {
+      await nextItemPromise
+    }
+  }
+}
+
 export async function simulateEpoch(
   validator: Validator,
   pools: StakerPoolData[],
@@ -38,9 +153,6 @@ export async function simulateEpoch(
       throw new Error('No active wallet found')
     }
 
-    // Set block time to payout frequency (in seconds)
-    await algodClient.setBlockOffsetTimestamp(validator.config.epochRoundLength * 60).do()
-
     toast.loading(
       `Sign to send ${AlgoAmount.Algos(rewardAmount).algos} ALGO reward to ` +
         `${`${pools.length} pool${pools.length > 1 ? 's' : ''}`}`,
@@ -48,8 +160,9 @@ export async function simulateEpoch(
     )
 
     const atc = new algosdk.AtomicTransactionComposer()
-    const suggestedParams = await ParamsCache.getSuggestedParams()
+    const suggestedParams = await algodClient.getTransactionParams().do()
 
+    // Create atomic transaction to send rewards to each pool
     for (const pool of pools) {
       const poolKey = pool.poolKey
 
@@ -63,19 +176,40 @@ export async function simulateEpoch(
       atc.addTransaction({ txn: paymentTxn, signer })
     }
 
+    // Send rewards to each pool
     await atc.execute(algodClient, 4)
 
-    // Reset block time
-    await algodClient.setBlockOffsetTimestamp(0).do()
+    toast.success('ALGO rewards sent to pools!', { id: toastId, duration: 3000 })
 
-    for (const pool of pools) {
-      const poolKey = pool.poolKey
-      toast.loading(`Sign for Pool ${poolKey.poolId} epoch balance update`, { id: toastId })
+    await wait(3000)
 
-      await epochBalanceUpdate(poolKey.poolAppId, signer, activeAddress, authAddr)
-    }
+    // Calculate the number of rounds to simulate an epoch
+    const { epochRoundLength } = validator.config
+    const numRounds = Math.ceil(320 + epochRoundLength + epochRoundLength / 2)
 
-    toast.success('Epoch balance update complete!', { id: toastId })
+    // Pass promise to toast.promise to handle loading, success, and error states
+    const incrementPromise = incrementRoundNumberBy(numRounds)
+    toast.promise(incrementPromise, {
+      loading: 'Simulating epoch...',
+      success: (data) => (
+        <span className="text-foreground">
+          Simulated {data.rounds} rounds:{' '}
+          <span className="whitespace-nowrap">
+            {data.startRound} &raquo; {data.resultRound}
+          </span>
+        </span>
+      ),
+      error: 'Error simulating epoch',
+      duration: 3000,
+    })
+
+    // Simulate the epoch
+    await incrementPromise
+
+    await wait(3000)
+
+    // Trigger payouts by calling epochBalanceUpdate, starting with first pool (will iterate through all pools)
+    await triggerPoolPayouts(pools, signer, activeAddress, authAddr)
 
     queryClient.invalidateQueries({ queryKey: ['stakes', { staker: activeAddress }] })
     router.invalidate()
@@ -84,8 +218,6 @@ export async function simulateEpoch(
 
     console.error(error)
     throw error
-  } finally {
-    await algodClient.setBlockOffsetTimestamp(0).do()
   }
 }
 


### PR DESCRIPTION
This updates the `simulateEpoch` function to work with the new rounds-based epoch lengths.

First a hard coded amount (currently 100 ALGO) is sent to each of the validator's pools.

The only way to advance blocks on localnet is to sign and send zero-pay transactions to a test account. Using 320-round postdating and the validator's epoch length, the number of blocks required is calculated and a loop signs and sends a transaction for each block until an epoch has transpired.

Then the `epochBalanceUpdate` call is fired for each pool. This triggers payouts of the rewards based on stake and eligibility. Since these calls require signatures, after each call the success toast displays a button to click to advance to the next pool (to prevent errors in wallets like Lute which require user interaction for each signature request).

This also adds a "Simulate Epoch" button to each validator in the `ValidatorTable`, so the owner is not required to have stake in the validator to trigger payouts.