### PR TITLE
feat(ui): format/convert number util function improvements

### DIFF
--- a/ui/src/components/AddPoolModal.tsx
+++ b/ui/src/components/AddPoolModal.tsx
@@ -1,4 +1,3 @@
-import { AlgoAmount } from '@algorandfoundation/algokit-utils/types/amount'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { ProgressBar } from '@tremor/react'
@@ -97,7 +96,7 @@ export function AddPoolModal({
         message: 'Required field',
       })
       .refine(() => availableBalance >= poolMbr, {
-        message: `Insufficient balance: ${formatAlgoAmount(AlgoAmount.MicroAlgos(poolMbr).algos)} ALGO required`,
+        message: `Insufficient balance: ${formatAlgoAmount(poolMbr)} ALGO required`,
       })
       .refine(
         (val) => {
@@ -215,9 +214,7 @@ export function AddPoolModal({
       }
 
       if (availableBalance < poolInitMbr) {
-        throw new Error(
-          `Insufficient balance: ${formatAlgoAmount(AlgoAmount.MicroAlgos(poolInitMbr).algos)} ALGO required`,
-        )
+        throw new Error(`Insufficient balance: ${formatAlgoAmount(poolInitMbr)} ALGO required`)
       }
 
       toast.loading(`Sign transaction to pay MBR for pool ${poolKey.poolId}...`, {

--- a/ui/src/components/AddStakeModal.tsx
+++ b/ui/src/components/AddStakeModal.tsx
@@ -161,7 +161,7 @@ export function AddStakeModal({
               minimum: minimumStake,
               type: 'number',
               inclusive: true,
-              message: `Minimum entry stake is ${formatAlgoAmount(AlgoAmount.MicroAlgos(minimumStake).algos)} ALGO`,
+              message: `Minimum entry stake is ${formatAlgoAmount(minimumStake)} ALGO`,
             })
           }
 

--- a/ui/src/components/AddStakeModal.tsx
+++ b/ui/src/components/AddStakeModal.tsx
@@ -51,7 +51,7 @@ import {
 } from '@/utils/contracts'
 import { ellipseAddressJsx } from '@/utils/ellipseAddress'
 import { ExplorerLink } from '@/utils/explorer'
-import { formatAlgoAmount, formatNumber } from '@/utils/format'
+import { formatAlgoAmount, formatAmount } from '@/utils/format'
 
 interface AddStakeModalProps {
   validator: Validator | null
@@ -473,7 +473,7 @@ export function AddStakeModal({
             {![GatingType.None, GatingType.SegmentNfd].includes(entryGatingType) && (
               <div className="pt-4">
                 <strong className="font-medium text-muted-foreground">Minimum Balance:</strong>{' '}
-                <span className="font-mono">{formatNumber(gatingAssetMinBalance.toString())}</span>
+                <span className="font-mono">{formatAmount(gatingAssetMinBalance.toString())}</span>
               </div>
             )}
           </div>

--- a/ui/src/components/UnstakeModal.tsx
+++ b/ui/src/components/UnstakeModal.tsx
@@ -112,7 +112,7 @@ export function UnstakeModal({ validator, setValidator, stakesByValidator }: Uns
                 maximum: currentBalance - minimumStake,
                 type: 'number',
                 inclusive: true,
-                message: `Minimum stake is ${formatAlgoAmount(AlgoAmount.MicroAlgos(minimumStake).algos)} ALGO`,
+                message: `Minimum stake is ${formatAlgoAmount(minimumStake)} ALGO`,
               })
             }
           }

--- a/ui/src/components/ValidatorDetails/Details.tsx
+++ b/ui/src/components/ValidatorDetails/Details.tsx
@@ -14,7 +14,7 @@ import { Validator } from '@/interfaces/validator'
 import { dayjs } from '@/utils/dayjs'
 import { ellipseAddressJsx } from '@/utils/ellipseAddress'
 import { ExplorerLink } from '@/utils/explorer'
-import { convertFromBaseUnits, formatAssetAmount, formatNumber } from '@/utils/format'
+import { convertFromBaseUnits, formatNumber } from '@/utils/format'
 import { getNfdAppFromViteEnvironment } from '@/utils/network/getNfdConfig'
 
 const nfdAppUrl = getNfdAppFromViteEnvironment()
@@ -70,8 +70,8 @@ export function Details({ validator }: DetailsProps) {
     }
 
     const convertedAmount = convertFromBaseUnits(
-      Number(validator.config.rewardPerPayout),
-      Number(validator.rewardToken.params.decimals),
+      validator.config.rewardPerPayout,
+      validator.rewardToken.params.decimals,
     )
 
     return (
@@ -101,6 +101,7 @@ export function Details({ validator }: DetailsProps) {
             </a>
           </>
         )
+      // @todo: Fetch gating assets and display unit names
       case GatingType.AssetId:
         return (
           <>
@@ -322,6 +323,7 @@ export function Details({ validator }: DetailsProps) {
                     </dd>
                   </div>
 
+                  {/* @todo: convertFromBaseUnits each asset's min balance and display unit name */}
                   {![GatingType.None, GatingType.SegmentNfd].includes(
                     validator.config.entryGatingType,
                   ) && (
@@ -330,7 +332,7 @@ export function Details({ validator }: DetailsProps) {
                         Gating Asset Minimum Balance
                       </dt>
                       <dd className="flex items-center justify-between gap-x-2 text-sm font-mono leading-6">
-                        {formatAssetAmount(validator.config.gatingAssetMinBalance.toString())}
+                        {formatNumber(validator.config.gatingAssetMinBalance.toString())}
                       </dd>
                     </div>
                   )}

--- a/ui/src/components/ValidatorDetails/Details.tsx
+++ b/ui/src/components/ValidatorDetails/Details.tsx
@@ -14,7 +14,7 @@ import { Validator } from '@/interfaces/validator'
 import { dayjs } from '@/utils/dayjs'
 import { ellipseAddressJsx } from '@/utils/ellipseAddress'
 import { ExplorerLink } from '@/utils/explorer'
-import { convertFromBaseUnits, formatNumber } from '@/utils/format'
+import { convertFromBaseUnits, formatAmount } from '@/utils/format'
 import { getNfdAppFromViteEnvironment } from '@/utils/network/getNfdConfig'
 
 const nfdAppUrl = getNfdAppFromViteEnvironment()
@@ -76,7 +76,7 @@ export function Details({ validator }: DetailsProps) {
 
     return (
       <span className="font-mono">
-        {formatNumber(convertedAmount)} {validator.rewardToken.params['unit-name']}
+        {formatAmount(convertedAmount)} {validator.rewardToken.params['unit-name']}
       </span>
     )
   }
@@ -251,7 +251,7 @@ export function Details({ validator }: DetailsProps) {
                 </dt>
                 <dd className="flex items-center justify-between gap-x-2 text-sm leading-6">
                   <span className="capitalize">
-                    {formatNumber(validator.config.epochRoundLength)} blocks
+                    {formatAmount(validator.config.epochRoundLength)} blocks
                   </span>
                 </dd>
               </div>
@@ -332,7 +332,7 @@ export function Details({ validator }: DetailsProps) {
                         Gating Asset Minimum Balance
                       </dt>
                       <dd className="flex items-center justify-between gap-x-2 text-sm font-mono leading-6">
-                        {formatNumber(validator.config.gatingAssetMinBalance.toString())}
+                        {formatAmount(validator.config.gatingAssetMinBalance.toString())}
                       </dd>
                     </div>
                   )}

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -60,7 +60,7 @@ import {
 import { dayjs, formatDuration } from '@/utils/dayjs'
 import { sendRewardTokensToPool } from '@/utils/development'
 import { ellipseAddressJsx } from '@/utils/ellipseAddress'
-import { formatNumber } from '@/utils/format'
+import { formatAmount } from '@/utils/format'
 import { cn } from '@/utils/ui'
 
 interface ValidatorTableProps {
@@ -262,7 +262,7 @@ export function ValidatorTable({
       cell: ({ row }) => {
         const validator = row.original
         const epochLength = validator.config.epochRoundLength
-        const numRounds = formatNumber(epochLength)
+        const numRounds = formatAmount(epochLength)
         const durationEstimate = epochLength * blockTime.ms
 
         return (

--- a/ui/src/hooks/useBlockTime.ts
+++ b/ui/src/hooks/useBlockTime.ts
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { blockTimeQueryOptions } from '@/api/queries'
 import { calculateAverageBlockTime } from '@/utils/blocks'
-import { formatNumber } from '@/utils/format'
+import { formatAmount } from '@/utils/format'
 
 export interface BlockTime {
   ms: number
@@ -11,7 +11,7 @@ export interface BlockTime {
 export function useBlockTime(): BlockTime {
   const { data: timestamps = [] } = useQuery(blockTimeQueryOptions)
   const ms = calculateAverageBlockTime(timestamps)
-  const secs = ms ? Number(formatNumber(ms / 1000, { precision: 1, trim: true })) : 0
+  const secs = ms ? Number(formatAmount(ms / 1000, { precision: 1, trim: true })) : 0
 
   return { ms, secs }
 }

--- a/ui/src/utils/development.ts
+++ b/ui/src/utils/development.ts
@@ -127,11 +127,7 @@ export async function sendRewardTokensToPool(
     const poolAccountInfo = await fetchAccountInformation(poolAddress)
     const assetHolding = poolAccountInfo.assets?.find((a) => a['asset-id'] === tokenId)
 
-    const balanceStr = formatAssetAmount(
-      assetHolding?.amount || 0,
-      true,
-      Number(asset.params.decimals),
-    )
+    const balanceStr = formatAssetAmount(asset, assetHolding?.amount || 0)
     const balanceMsg = assetHolding?.amount ? `${balanceStr} ${unitName}` : 'unknown'
 
     toast.success(`Success! New Balance: ${balanceMsg}`, {

--- a/ui/src/utils/format.spec.ts
+++ b/ui/src/utils/format.spec.ts
@@ -1,9 +1,9 @@
+import { Asset } from '@/interfaces/algod'
 import {
   convertFromBaseUnits,
   convertToBaseUnits,
   formatAlgoAmount,
   formatAssetAmount,
-  formatBigIntWithCommas,
   formatNumber,
   formatWithPrecision,
   roundToFirstNonZeroDecimal,
@@ -18,6 +18,25 @@ describe('convertFromBaseUnits', () => {
   it('should handle zero decimals correctly', () => {
     expect(convertFromBaseUnits(12345, 0)).toBe(12345)
   })
+
+  it('should handle bigint inputs', () => {
+    expect(convertFromBaseUnits(1000000n, 6)).toBe(1)
+    expect(convertFromBaseUnits(1234567n, 3)).toBe(1234.567)
+  })
+
+  it('should handle string inputs', () => {
+    expect(convertFromBaseUnits('1000000', 6)).toBe(1)
+    expect(convertFromBaseUnits('1234567', 3)).toBe(1234.567)
+  })
+
+  it('should handle bigint decimals', () => {
+    expect(convertFromBaseUnits(1000000, 6n)).toBe(1)
+    expect(convertFromBaseUnits(1234567, 3n)).toBe(1234.567)
+  })
+
+  it('should return NaN for invalid inputs', () => {
+    expect(convertFromBaseUnits('invalid', 6)).toBeNaN()
+  })
 })
 
 describe('convertToBaseUnits', () => {
@@ -29,62 +48,24 @@ describe('convertToBaseUnits', () => {
   it('should handle zero decimals correctly', () => {
     expect(convertToBaseUnits(12345, 0)).toBe(12345)
   })
-})
 
-describe('formatWithPrecision', () => {
-  it('should format a number with precision and suffixes, trimming zeros', () => {
-    expect(formatWithPrecision(1e12, 3)).toBe('1T')
-    expect(formatWithPrecision(2.345e12, 1)).toBe('2.3T')
-    expect(formatWithPrecision(3.45678e9, 2)).toBe('3.46B')
-    expect(formatWithPrecision(4.56789e6, 3)).toBe('4.568M')
-    expect(formatWithPrecision(1234.567, 2)).toBe('1.23K')
-  })
-})
-
-describe('formatAssetAmount', () => {
-  it('should format asset amounts correctly', () => {
-    expect(formatAssetAmount(1234567, true, 6)).toBe('1.234567')
-    expect(formatAssetAmount(1000, false, 0)).toBe('1,000')
+  it('should handle bigint inputs', () => {
+    expect(convertToBaseUnits(1n, 6)).toBe(1000000)
+    expect(convertToBaseUnits(1234n, 3)).toBe(1234000)
   })
 
-  it('should trim trailing zeros when trim is true', () => {
-    expect(formatAssetAmount(1000, false, 6, true)).toBe('1,000')
-    expect(formatAssetAmount(1234.56789, false, 6, true)).toBe('1,234.56789')
+  it('should handle string inputs', () => {
+    expect(convertToBaseUnits('1', 6)).toBe(1000000)
+    expect(convertToBaseUnits('1234.567', 3)).toBe(1234567)
   })
 
-  it('should retain trailing zeros when trim is false', () => {
-    expect(formatAssetAmount(1000, false, 6, false)).toBe('1,000.000000')
+  it('should handle bigint decimals', () => {
+    expect(convertToBaseUnits(1, 6n)).toBe(1000000)
+    expect(convertToBaseUnits(1234, 3n)).toBe(1234000)
   })
 
-  it('should handle an invalid amount gracefully', () => {
-    expect(formatAssetAmount('abc', true, 6)).toBe('NaN')
-  })
-
-  it('should apply the maxLength option', () => {
-    expect(formatAssetAmount(1234567890, false, 2, true, 6)).toBe('1.2B')
-    expect(formatAssetAmount(1000000, false, 6, true, 5)).toBe('1M')
-    expect(formatAssetAmount(987654321, false, 3, true, 8)).toBe('987.7M')
-  })
-})
-
-describe('formatAlgoAmount', () => {
-  it('should format Algorand amounts correctly', () => {
-    expect(formatAlgoAmount(1234567, true)).toBe('1.234567')
-    expect(formatAlgoAmount(1000000, true)).toBe('1')
-  })
-})
-
-describe('roundToFirstNonZeroDecimal', () => {
-  it('should round to the first non-zero decimal', () => {
-    expect(roundToFirstNonZeroDecimal(0.001234)).toBe(0.001)
-    expect(roundToFirstNonZeroDecimal(0.0005678)).toBe(0.0006)
-    expect(roundToFirstNonZeroDecimal(1234.567)).toBe(1234.567)
-  })
-})
-
-describe('formatBigIntWithCommas', () => {
-  it('should format a BigInt with commas', () => {
-    expect(formatBigIntWithCommas(12345678901234567890n)).toBe('12,345,678,901,234,567,890')
+  it('should return NaN for invalid inputs', () => {
+    expect(convertToBaseUnits('invalid', 6)).toBeNaN()
   })
 })
 
@@ -109,9 +90,20 @@ describe('formatNumber', () => {
     expect(result).toBe('1.23M')
   })
 
+  it('should format Number.MAX_SAFE_INTEGER correctly', () => {
+    const result = formatNumber(Number.MAX_SAFE_INTEGER)
+    expect(result).toBe('9007.2T')
+  })
+
   it('should format a bigint correctly', () => {
-    const result = formatNumber(12345678901234567890n)
-    expect(result).toBe('12,345,678,901,234,567,890')
+    const result = formatNumber(1234567n)
+    expect(result).toBe('1,234,567')
+
+    const compactResult = formatNumber(1234567890123456n)
+    expect(compactResult).toBe('1234.6T')
+
+    const expoResult = formatNumber(12345678901234567890n)
+    expect(expoResult).toBe('1.23e+19')
   })
 
   it('should format a string representation of a number', () => {
@@ -132,5 +124,140 @@ describe('formatNumber', () => {
   it('should handle negative numbers correctly', () => {
     const result = formatNumber(-9876543.21, { precision: 2 })
     expect(result).toBe('-9,876,543.21')
+  })
+
+  it('should format a number using the decimals option', () => {
+    const result = formatNumber(1234567890, { decimals: 2 })
+    expect(result).toBe('12,345,678.9')
+
+    const bigIntResult = formatNumber(12345678901234n, { decimals: 6 })
+    expect(bigIntResult).toBe('12,345,678.901234')
+  })
+
+  it('should format a number with maxLength option', () => {
+    const result = formatNumber(1234567890, { maxLength: 5 })
+    expect(result).toBe('1.2B')
+
+    const preciseResult = formatNumber(1234567890.12345, { maxLength: 16 })
+    expect(preciseResult).toBe('1,234,567,890.12345')
+
+    const compactResult = formatNumber(1234567890.12345, { maxLength: 15 })
+    expect(compactResult).toBe('1.2B')
+  })
+})
+
+describe('formatWithPrecision', () => {
+  it('should format a number with precision and suffixes, trimming zeros', () => {
+    expect(formatWithPrecision(1e12, 3)).toBe('1T')
+    expect(formatWithPrecision(2.345e12, 1)).toBe('2.3T')
+    expect(formatWithPrecision(3.45678e9, 2)).toBe('3.46B')
+    expect(formatWithPrecision(4.56789e6, 3)).toBe('4.568M')
+    expect(formatWithPrecision(1234.567, 2)).toBe('1.23K')
+  })
+})
+
+describe('formatAssetAmount', () => {
+  const asset: Asset = {
+    params: {
+      creator: '',
+      decimals: 6,
+      name: 'Test Asset',
+      total: 1000000,
+      'unit-name': 'TEST',
+    },
+    index: 12345,
+  }
+
+  it('should format asset amount correctly with default options', () => {
+    const result = formatAssetAmount(asset, 1234567890)
+    expect(result).toBe('1,234.56789')
+  })
+
+  it('should format asset amount with precision option', () => {
+    const result = formatAssetAmount(asset, 1234567890, { precision: 2 })
+    expect(result).toBe('1,234.57')
+  })
+
+  it('should format asset amount with trim option', () => {
+    const result = formatAssetAmount(asset, 1234560000, { precision: 6, trim: true })
+    expect(result).toBe('1,234.56')
+  })
+
+  it('should format asset amount in compact notation', () => {
+    const result = formatAssetAmount(asset, 1234567890, { compact: true, precision: 2 })
+    expect(result).toBe('1.23K')
+  })
+
+  it('should handle bigint inputs correctly', () => {
+    const result = formatAssetAmount(asset, 1234567890n)
+    expect(result).toBe('1,234.56789')
+  })
+
+  it('should handle string inputs correctly', () => {
+    const result = formatAssetAmount(asset, '1234567890')
+    expect(result).toBe('1,234.56789')
+  })
+
+  it('should handle maximum length option', () => {
+    const result = formatAssetAmount(asset, 1234567890, { maxLength: 5 })
+    expect(result).toBe('1.2K')
+  })
+
+  it('should return NaN for invalid inputs', () => {
+    const result = formatAssetAmount(asset, 'invalid')
+    expect(result).toBe('NaN')
+  })
+})
+
+describe('formatAlgoAmount', () => {
+  it('should format Algo amount correctly with default options', () => {
+    const result = formatAlgoAmount(1234567890)
+    expect(result).toBe('1,234.56789')
+  })
+
+  it('should format Algo amount with precision option', () => {
+    const result = formatAlgoAmount(1234567890, { precision: 2 })
+    expect(result).toBe('1,234.57')
+  })
+
+  it('should format Algo amount with trim option', () => {
+    const result = formatAlgoAmount(1234560000, { precision: 6, trim: true })
+    expect(result).toBe('1,234.56')
+
+    const noTrimResult = formatAlgoAmount(1234560000, { precision: 6, trim: false })
+    expect(noTrimResult).toBe('1,234.560000')
+  })
+
+  it('should format Algo amount in compact notation', () => {
+    const result = formatAlgoAmount(1234567890, { compact: true, precision: 2 })
+    expect(result).toBe('1.23K')
+  })
+
+  it('should handle bigint inputs correctly', () => {
+    const result = formatAlgoAmount(1234567890n)
+    expect(result).toBe('1,234.56789')
+  })
+
+  it('should handle string inputs correctly', () => {
+    const result = formatAlgoAmount('1234567890')
+    expect(result).toBe('1,234.56789')
+  })
+
+  it('should handle maximum length option', () => {
+    const result = formatAlgoAmount(1234567890, { maxLength: 5 })
+    expect(result).toBe('1.2K')
+  })
+
+  it('should return NaN for invalid inputs', () => {
+    const result = formatAlgoAmount('invalid')
+    expect(result).toBe('NaN')
+  })
+})
+
+describe('roundToFirstNonZeroDecimal', () => {
+  it('should round to the first non-zero decimal', () => {
+    expect(roundToFirstNonZeroDecimal(0.001234)).toBe(0.001)
+    expect(roundToFirstNonZeroDecimal(0.0005678)).toBe(0.0006)
+    expect(roundToFirstNonZeroDecimal(1234.567)).toBe(1234.567)
   })
 })

--- a/ui/src/utils/format.spec.ts
+++ b/ui/src/utils/format.spec.ts
@@ -4,7 +4,7 @@ import {
   convertToBaseUnits,
   formatAlgoAmount,
   formatAssetAmount,
-  formatNumber,
+  formatAmount,
   formatWithPrecision,
   roundToFirstNonZeroDecimal,
 } from '@/utils/format'
@@ -69,79 +69,79 @@ describe('convertToBaseUnits', () => {
   })
 })
 
-describe('formatNumber', () => {
+describe('formatAmount', () => {
   it('should format a large number with commas', () => {
-    const result = formatNumber(1234567890)
+    const result = formatAmount(1234567890)
     expect(result).toBe('1,234,567,890')
   })
 
   it('should format a number with a specified precision', () => {
-    const result = formatNumber(12345.6789, { precision: 2 })
+    const result = formatAmount(12345.6789, { precision: 2 })
     expect(result).toBe('12,345.68')
   })
 
   it('should include all decimal places if precision is undefined', () => {
-    const result = formatNumber(12345.6789)
+    const result = formatAmount(12345.6789)
     expect(result).toBe('12,345.6789')
   })
 
   it('should format a number in compact notation with precision', () => {
-    const result = formatNumber(1234567, { compact: true, precision: 2 })
+    const result = formatAmount(1234567, { compact: true, precision: 2 })
     expect(result).toBe('1.23M')
   })
 
   it('should format Number.MAX_SAFE_INTEGER correctly', () => {
-    const result = formatNumber(Number.MAX_SAFE_INTEGER)
+    const result = formatAmount(Number.MAX_SAFE_INTEGER)
     expect(result).toBe('9007.2T')
   })
 
   it('should format a bigint correctly', () => {
-    const result = formatNumber(1234567n)
+    const result = formatAmount(1234567n)
     expect(result).toBe('1,234,567')
 
-    const compactResult = formatNumber(1234567890123456n)
+    const compactResult = formatAmount(1234567890123456n)
     expect(compactResult).toBe('1234.6T')
 
-    const expoResult = formatNumber(12345678901234567890n)
+    const expoResult = formatAmount(12345678901234567890n)
     expect(expoResult).toBe('1.23e+19')
   })
 
   it('should format a string representation of a number', () => {
-    const result = formatNumber('987654321.1234', { precision: 3 })
+    const result = formatAmount('987654321.1234', { precision: 3 })
     expect(result).toBe('987,654,321.123')
   })
 
   it('should remove trailing zeros if trim is true', () => {
-    const result = formatNumber(100.5, { precision: 3, trim: true })
+    const result = formatAmount(100.5, { precision: 3, trim: true })
     expect(result).toBe('100.5')
   })
 
   it('should retain trailing zeros if trim is false', () => {
-    const result = formatNumber(100.5, { precision: 3, trim: false })
+    const result = formatAmount(100.5, { precision: 3, trim: false })
     expect(result).toBe('100.500')
   })
 
   it('should handle negative numbers correctly', () => {
-    const result = formatNumber(-9876543.21, { precision: 2 })
+    const result = formatAmount(-9876543.21, { precision: 2 })
     expect(result).toBe('-9,876,543.21')
   })
 
   it('should format a number using the decimals option', () => {
-    const result = formatNumber(1234567890, { decimals: 2 })
+    const result = formatAmount(1234567890, { decimals: 2 })
     expect(result).toBe('12,345,678.9')
 
-    const bigIntResult = formatNumber(12345678901234n, { decimals: 6 })
+    const bigIntResult = formatAmount(12345678901234n, { decimals: 6 })
     expect(bigIntResult).toBe('12,345,678.901234')
   })
 
   it('should format a number with maxLength option', () => {
-    const result = formatNumber(1234567890, { maxLength: 5 })
+    const result = formatAmount(1234567890, { maxLength: 5 })
     expect(result).toBe('1.2B')
 
-    const preciseResult = formatNumber(1234567890.12345, { maxLength: 16 })
+    const preciseResult = formatAmount(1234567890.12345, { maxLength: 16 })
     expect(preciseResult).toBe('1,234,567,890.12345')
 
-    const compactResult = formatNumber(1234567890.12345, { maxLength: 15 })
+    const compactResult = formatAmount(1234567890.12345, { maxLength: 15 })
     expect(compactResult).toBe('1.2B')
   })
 })

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -1,40 +1,133 @@
 import Big from 'big.js'
+import { Asset } from '@/interfaces/algod'
 
 /**
  * Convert an asset amount from base units to whole units
- * @param {number} amount - The amount in base units
- * @param {number} decimals - The number of decimal places
+ * @param {number | bigint | string} amount - The amount in base units
+ * @param {number | bigint} decimals - The number of decimal places
  * @returns {number} The amount in whole units
  * @example
  * convertFromBaseUnits(12345, 0) // 12345
  * convertFromBaseUnits(12345, 6) // 0.012345
  * convertFromBaseUnits(1000000, 6) // 1
  */
-export function convertFromBaseUnits(amount: number, decimals: number = 0): number {
-  if (decimals === 0) return amount
-  const divisor = new Big(10).pow(decimals)
-  return new Big(amount).div(divisor).toNumber()
+export function convertFromBaseUnits(
+  amount: number | bigint | string,
+  decimals: number | bigint = 0,
+): number {
+  try {
+    const divisor = decimals ? new Big(10).pow(Number(decimals)) : new Big(1)
+    const bigAmount = typeof amount === 'bigint' ? new Big(amount.toString()) : new Big(amount)
+    return bigAmount.div(divisor).toNumber()
+  } catch (error) {
+    return NaN
+  }
 }
 
 /**
  * Convert an asset amount from whole units to base units
- * @param {number} amount - The amount in whole units
- * @param {number} decimals - The number of decimal places
+ * @param {number | bigint | string} amount - The amount in whole units
+ * @param {number | bigint} decimals - The number of decimal places
  * @returns {number} The amount in base units
  * @example
  * convertToBaseUnits(1, 6) // 1000000
  * convertToBaseUnits(0.012345, 6) // 12345
  * convertToBaseUnits(12345, 0) // 12345
  */
-export function convertToBaseUnits(amount: number, decimals: number = 0): number {
-  if (decimals === 0) return amount
-  const multiplier = new Big(10).pow(decimals)
-  return new Big(amount).times(multiplier).toNumber()
+export function convertToBaseUnits(
+  amount: number | bigint | string,
+  decimals: number | bigint = 0,
+): number {
+  try {
+    const multiplier = decimals ? new Big(10).pow(Number(decimals)) : new Big(1)
+    const bigAmount = typeof amount === 'bigint' ? new Big(amount.toString()) : new Big(amount)
+    return bigAmount.times(multiplier).toNumber()
+  } catch (error) {
+    return NaN
+  }
+}
+
+type FormatNumberOptions = {
+  compact?: boolean
+  precision?: number
+  trim?: boolean
+  maxLength?: number
+  decimals?: number
+}
+
+/**
+ * Format a number with commas and optional decimal places
+ * @param {number | bigint | string} amount - The number to format
+ * @param {FormatNumberOptions} options - Options for formatting the number
+ * @param {boolean} options.compact - Whether to format the number in compact notation
+ * @param {number} options.precision - The number of decimal places
+ * @param {boolean} options.trim - Whether to trim trailing zeros
+ * @returns {string} The formatted number
+ * @example
+ * formatNumber(1234567890) // '1,234,567,890'
+ * formatNumber(12345.6789, { precision: 2 }) // '12,345.68'
+ * formatNumber(1234567, { compact: true, precision: 2 }) // '1.23M'
+ * formatNumber('987654321.1234', { precision: 3 }) // '987,654,321.123'
+ * formatNumber(100.5, { precision: 3, trim: true }) // '100.5'
+ * formatNumber(100.5, { precision: 3, trim: false }) // '100.500'
+ * formatNumber(-9876543.21, { precision: 2 }) // '-9,876,543.21'
+ */
+export function formatNumber(
+  amount: number | bigint | string,
+  options: FormatNumberOptions = {},
+): string {
+  const { compact = false, precision, trim = true, maxLength = 15, decimals } = options
+
+  const divisor = decimals ? new Big(10).pow(decimals) : new Big(1)
+
+  let fixedAmount: string
+
+  try {
+    const bigAmount =
+      typeof amount === 'bigint'
+        ? new Big(amount.toString()).div(divisor)
+        : new Big(amount).div(divisor)
+
+    if (bigAmount.gt(Number.MAX_SAFE_INTEGER)) {
+      return bigAmount.toExponential(2)
+    }
+
+    if (compact) {
+      return formatWithPrecision(bigAmount.toNumber(), precision || 0)
+    }
+
+    if (bigAmount.round().toString().length > Math.min(maxLength, 15)) {
+      return formatWithPrecision(bigAmount.toNumber(), precision || 1)
+    }
+
+    fixedAmount = bigAmount.toFixed(precision)
+  } catch (error) {
+    return 'NaN'
+  }
+
+  if (maxLength && fixedAmount.length > maxLength) {
+    return formatWithPrecision(fixedAmount, 1)
+  }
+
+  // Split the number into integer and decimal parts
+  let [integerPart, decimalPart] = fixedAmount.split('.')
+
+  // Add commas to the integer part
+  integerPart = new Intl.NumberFormat().format(parseInt(integerPart, 10))
+
+  // Handle decimal trimming
+  if (trim && decimalPart) {
+    decimalPart = decimalPart.replace(/\.?0+$/, '') // Trim trailing zeros
+  }
+
+  const formatted = !decimalPart ? integerPart : [integerPart, decimalPart].join('.')
+
+  return formatted
 }
 
 /**
  * Format a number with precision and suffixes
- * @param {number} num - The number to format
+ * @param {number | string} num - The number to format (can be a number or a string)
  * @param {number} precision - The number of decimal places
  * @returns {string} The formatted number with precision and suffixes
  * @example
@@ -44,23 +137,24 @@ export function convertToBaseUnits(amount: number, decimals: number = 0): number
  * formatWithPrecision(4.56789e6, 3) // '4.568M'
  * formatWithPrecision(1234.567, 2) // '1.23K'
  */
-export function formatWithPrecision(num: number, precision: number): string {
-  let scaledNum = num
+export function formatWithPrecision(num: number | string, precision: number): string {
+  const bigNum = new Big(num)
+  let scaledNum = bigNum
   let suffix = ''
 
   // Determine the appropriate suffix and scale the number
-  if (num >= 1e12) {
+  if (bigNum.gte(1e12)) {
     suffix = 'T'
-    scaledNum = num / 1e12
-  } else if (num >= 1e9) {
+    scaledNum = bigNum.div(1e12)
+  } else if (bigNum.gte(1e9)) {
     suffix = 'B'
-    scaledNum = num / 1e9
-  } else if (num >= 1e6) {
+    scaledNum = bigNum.div(1e9)
+  } else if (bigNum.gte(1e6)) {
     suffix = 'M'
-    scaledNum = num / 1e6
-  } else if (num >= 1e3) {
+    scaledNum = bigNum.div(1e6)
+  } else if (bigNum.gte(1e3)) {
     suffix = 'K'
-    scaledNum = num / 1e3
+    scaledNum = bigNum.div(1e3)
   }
 
   // Format the number with precision and trim trailing zeros
@@ -69,81 +163,68 @@ export function formatWithPrecision(num: number, precision: number): string {
   return formattedNumber + suffix
 }
 
-// @todo: Convert options to an object
+type FormatAssetAmountOptions = Omit<FormatNumberOptions, 'decimals'>
+
 /**
- * Format an asset amount with commas and optional decimal places
- * @param {number | string} amount - The asset amount to format
- * @param {boolean} baseUnits - Whether the amount is in base units
- * @param {number} decimals - The number of decimal places
- * @param {boolean} trim - Whether to trim trailing zeros
- * @param {number} maxLength - The maximum length of the formatted string
+ * Format an asset base unit amount for display in whole units.
+ * Expects the asset with AssetParams fetched from `/v2/assets/{asset-id}`.
+ * Passes the amount to formatNumber with the appropriate options.
+ * @param {Asset} asset - The asset to format the amount for
+ * @param {number | bigint | string} amount - The asset amount to format
+ * @param {FormatAssetAmountOptions} options - Options for formatting the amount
  * @returns {string} The formatted asset amount
  * @example
- * formatAssetAmount(1234567, true, 6) // '1.234567'
- * formatAssetAmount(1000, false, 0) // '1,000'
- * formatAssetAmount(1234.56789, false, 6, true) // '1,234.56789'
- * formatAssetAmount(1000, false, 6, false) // '1,000.000000'
- * formatAssetAmount('abc', true, 6) // 'NaN'
- * formatAssetAmount(1234.56789, false, 6, true, 10) // '1.2K'
+ * const asset: Asset = {
+ *   index: 12345,
+ *   params: {
+ *     decimals: 6,
+ *     // ...
+ *   },
+ * }
+ * formatAssetAmount(asset, 1234567890) // '1,234.56789'
+ * formatAssetAmount(asset, 1234567890, { precision: 2 }) // '1,234.57'
+ * formatAssetAmount(asset, 1234560000, { precision: 6, trim: true }) // '1,234.56'
+ * formatAssetAmount(asset, 1234567890, { compact: true, precision: 2 }) // '1.23K'
+ * formatAssetAmount(asset, 1234567890n) // '1,234.56789'
+ * formatAssetAmount(asset, '1234567890') // '1,234.56789'
+ * @see {@link formatNumber}
  */
 export function formatAssetAmount(
-  amount: number | string,
-  baseUnits: boolean = false,
-  decimals: number = 6,
-  trim: boolean = true,
-  maxLength?: number,
+  asset: Asset,
+  amount: number | bigint | string,
+  options: FormatAssetAmountOptions = {},
 ): string {
-  // If amount is a string, parse it to a number
-  const numAmount = typeof amount === 'string' ? parseFloat(amount) : amount
-  if (isNaN(numAmount)) return 'NaN'
+  const { precision, trim, maxLength, compact } = options
+  const decimals = Number(asset.params.decimals)
 
-  // Convert to string
-  // If amount is in base units, convert from base units
-  const formatted = baseUnits
-    ? convertFromBaseUnits(numAmount, decimals).toFixed(decimals)
-    : new Big(numAmount).toFixed(decimals)
+  const formatOptions = { precision, trim, maxLength, compact, decimals }
 
-  const parts = formatted.split('.')
-
-  if (trim && parts.length === 2) {
-    parts[1] = parts[1].replace(/\.?0+$/, '')
-  }
-
-  if (maxLength && parts.join('.').length > maxLength) {
-    return formatWithPrecision(parseFloat(formatted), 1)
-  }
-
-  // Format number with commas, but don't affect decimal places
-  parts[0] = new Intl.NumberFormat().format(parseFloat(parts[0]))
-
-  if (parts[1] === '') {
-    return parts[0]
-  }
-
-  return parts.join('.')
+  return formatNumber(amount, formatOptions)
 }
 
-// @todo: Convert options to an object
 /**
- * Format an Algo amount with commas and optional decimal places
- * @param {number | string} amount - The Algo amount to format
- * @param {boolean} microalgos - Whether the amount is in microalgos
- * @param {boolean} trim - Whether to trim trailing zeros
- * @param {number} maxLength - The maximum length of the formatted string
+ * Format a MicroAlgos amount for display in Algos.
+ * Passes the amount to formatNumber with the appropriate options.
+ * @param {number | bigint | string} amount - The MicroAlgos amount to format
+ * @param {FormatAssetAmountOptions} options - Options for formatting the amount
  * @returns {string} The formatted Algo amount
  * @example
- * formatAlgoAmount(1234567, true) // '1.234567'
- * formatAlgoAmount(1000, false) // '1,000'
- * formatAlgoAmount(1234.56789, false, true) // '1,234.56789'
- * formatAlgoAmount(1000, false, false) // '1,000.000000'
+ * formatAlgoAmount(1234567890) // '1,234.56789'
+ * formatAlgoAmount(1234567890, { precision: 2 }) // '1,234.57'
+ * formatAlgoAmount(1234567890, { compact: true, precision: 2 }) // '1.23K'
+ * formatAlgoAmount(1234567890n) // '1,234.56789'
+ * formatAlgoAmount('1234567890') // '1,234.56789'
+ * @see {@link formatNumber}
  */
 export function formatAlgoAmount(
-  amount: number | string,
-  microalgos: boolean = false,
-  trim: boolean = true,
-  maxLength?: number,
+  amount: number | bigint | string,
+  options: FormatAssetAmountOptions = {},
 ): string {
-  return formatAssetAmount(amount, microalgos, 6, trim, maxLength)
+  const { precision, trim, maxLength, compact } = options
+
+  const formatOptions = { precision, trim, maxLength, compact, decimals: 6 }
+
+  return formatNumber(amount, formatOptions)
 }
 
 /**
@@ -167,73 +248,4 @@ export function roundToFirstNonZeroDecimal(num: number): number {
 
   // Use toFixed to round to the first significant decimal place
   return Number(num.toFixed(decimalPlaces))
-}
-
-/**
- * Format a BigInt with commas
- * @param {bigint} value - The BigInt value
- * @returns {string} The formatted BigInt value with commas
- * @example
- * formatBigIntWithCommas(12345678901234567890n) // '12,345,678,901,234,567,890'
- */
-export function formatBigIntWithCommas(value: bigint): string {
-  const valueStr = value.toString()
-  const regex = /\B(?=(\d{3})+(?!\d))/g
-  return valueStr.replace(regex, ',')
-}
-
-type FormatNumberOptions = {
-  compact?: boolean
-  precision?: number
-  trim?: boolean
-}
-
-/**
- * Format a number with commas and optional decimal places
- * @param {number | bigint | string} amount - The number to format
- * @param {FormatNumberOptions} options - Options for formatting the number
- * @param {boolean} options.compact - Whether to format the number in compact notation
- * @param {number} options.precision - The number of decimal places
- * @param {boolean} options.trim - Whether to trim trailing zeros
- * @returns {string} The formatted number
- * @example
- * formatNumber(1234567890) // '1,234,567,890'
- * formatNumber(12345.6789, { precision: 2 }) // '12,345.68'
- * formatNumber(1234567, { compact: true, precision: 2 }) // '1.23M'
- * formatNumber(12345678901234567890n) // '12,345,678,901,234,567,890'
- * formatNumber('987654321.1234', { precision: 3 }) // '987,654,321.123'
- * formatNumber(100.5, { precision: 3, trim: true }) // '100.5'
- * formatNumber(100.5, { precision: 3, trim: false }) // '100.500'
- * formatNumber(-9876543.21, { precision: 2 }) // '-9,876,543.21'
- */
-export function formatNumber(
-  amount: number | bigint | string,
-  options: FormatNumberOptions = {},
-): string {
-  const { compact = false, precision, trim = true } = options
-
-  // Handle BigInt separately to preserve precision
-  if (typeof amount === 'bigint') {
-    const formattedBigInt = formatBigIntWithCommas(amount)
-    return formattedBigInt
-  }
-
-  const numericAmount = parseFloat(String(amount))
-
-  if (compact) {
-    return formatWithPrecision(numericAmount, precision || 0)
-  }
-
-  const bigAmount = new Big(numericAmount).toFixed(precision)
-  const parts = bigAmount.split('.')
-
-  // Add commas to the integer part
-  parts[0] = new Intl.NumberFormat().format(parseInt(parts[0], 10))
-
-  // Handle decimal trimming
-  if (trim && parts.length === 2) {
-    parts[1] = parts[1].replace(/\.?0+$/, '') // Trim trailing zeros
-  }
-
-  return parts.length === 1 ? parts[0] : parts.join('.')
 }

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -62,6 +62,8 @@ type FormatAmountOptions = {
  * @param {boolean} options.compact - Whether to format the number in compact notation
  * @param {number} options.precision - The number of decimal places
  * @param {boolean} options.trim - Whether to trim trailing zeros
+ * @param {number} options.maxLength - The maximum length of the formatted number
+ * @param {number} options.decimals - The number of decimal places for base unit conversion
  * @returns {string} The formatted number
  * @example
  * formatAmount(1234567890) // '1,234,567,890'
@@ -70,7 +72,7 @@ type FormatAmountOptions = {
  * formatAmount('987654321.1234', { precision: 3 }) // '987,654,321.123'
  * formatAmount(100.5, { precision: 3, trim: true }) // '100.5'
  * formatAmount(100.5, { precision: 3, trim: false }) // '100.500'
- * formatAmount(-9876543.21, { precision: 2 }) // '-9,876,543.21'
+ * formatAmount(123456789, { decimals: 2 }) // '1,234,567.89'
  */
 export function formatAmount(
   amount: number | bigint | string,

--- a/ui/src/utils/format.ts
+++ b/ui/src/utils/format.ts
@@ -47,7 +47,7 @@ export function convertToBaseUnits(
   }
 }
 
-type FormatNumberOptions = {
+type FormatAmountOptions = {
   compact?: boolean
   precision?: number
   trim?: boolean
@@ -56,25 +56,25 @@ type FormatNumberOptions = {
 }
 
 /**
- * Format a number with commas and optional decimal places
+ * Format an amount with options for base unit conversion, precision, compact notation, and trimming
  * @param {number | bigint | string} amount - The number to format
- * @param {FormatNumberOptions} options - Options for formatting the number
+ * @param {FormatAmountOptions} options - Options for formatting the number
  * @param {boolean} options.compact - Whether to format the number in compact notation
  * @param {number} options.precision - The number of decimal places
  * @param {boolean} options.trim - Whether to trim trailing zeros
  * @returns {string} The formatted number
  * @example
- * formatNumber(1234567890) // '1,234,567,890'
- * formatNumber(12345.6789, { precision: 2 }) // '12,345.68'
- * formatNumber(1234567, { compact: true, precision: 2 }) // '1.23M'
- * formatNumber('987654321.1234', { precision: 3 }) // '987,654,321.123'
- * formatNumber(100.5, { precision: 3, trim: true }) // '100.5'
- * formatNumber(100.5, { precision: 3, trim: false }) // '100.500'
- * formatNumber(-9876543.21, { precision: 2 }) // '-9,876,543.21'
+ * formatAmount(1234567890) // '1,234,567,890'
+ * formatAmount(12345.6789, { precision: 2 }) // '12,345.68'
+ * formatAmount(1234567, { compact: true, precision: 2 }) // '1.23M'
+ * formatAmount('987654321.1234', { precision: 3 }) // '987,654,321.123'
+ * formatAmount(100.5, { precision: 3, trim: true }) // '100.5'
+ * formatAmount(100.5, { precision: 3, trim: false }) // '100.500'
+ * formatAmount(-9876543.21, { precision: 2 }) // '-9,876,543.21'
  */
-export function formatNumber(
+export function formatAmount(
   amount: number | bigint | string,
-  options: FormatNumberOptions = {},
+  options: FormatAmountOptions = {},
 ): string {
   const { compact = false, precision, trim = true, maxLength = 15, decimals } = options
 
@@ -163,12 +163,12 @@ export function formatWithPrecision(num: number | string, precision: number): st
   return formattedNumber + suffix
 }
 
-type FormatAssetAmountOptions = Omit<FormatNumberOptions, 'decimals'>
+type FormatAssetAmountOptions = Omit<FormatAmountOptions, 'decimals'>
 
 /**
  * Format an asset base unit amount for display in whole units.
  * Expects the asset with AssetParams fetched from `/v2/assets/{asset-id}`.
- * Passes the amount to formatNumber with the appropriate options.
+ * Passes the amount to formatAmount with the appropriate options.
  * @param {Asset} asset - The asset to format the amount for
  * @param {number | bigint | string} amount - The asset amount to format
  * @param {FormatAssetAmountOptions} options - Options for formatting the amount
@@ -187,7 +187,7 @@ type FormatAssetAmountOptions = Omit<FormatNumberOptions, 'decimals'>
  * formatAssetAmount(asset, 1234567890, { compact: true, precision: 2 }) // '1.23K'
  * formatAssetAmount(asset, 1234567890n) // '1,234.56789'
  * formatAssetAmount(asset, '1234567890') // '1,234.56789'
- * @see {@link formatNumber}
+ * @see {@link formatAmount}
  */
 export function formatAssetAmount(
   asset: Asset,
@@ -199,12 +199,12 @@ export function formatAssetAmount(
 
   const formatOptions = { precision, trim, maxLength, compact, decimals }
 
-  return formatNumber(amount, formatOptions)
+  return formatAmount(amount, formatOptions)
 }
 
 /**
  * Format a MicroAlgos amount for display in Algos.
- * Passes the amount to formatNumber with the appropriate options.
+ * Passes the amount to formatAmount with the appropriate options.
  * @param {number | bigint | string} amount - The MicroAlgos amount to format
  * @param {FormatAssetAmountOptions} options - Options for formatting the amount
  * @returns {string} The formatted Algo amount
@@ -214,7 +214,7 @@ export function formatAssetAmount(
  * formatAlgoAmount(1234567890, { compact: true, precision: 2 }) // '1.23K'
  * formatAlgoAmount(1234567890n) // '1,234.56789'
  * formatAlgoAmount('1234567890') // '1,234.56789'
- * @see {@link formatNumber}
+ * @see {@link formatAmount}
  */
 export function formatAlgoAmount(
   amount: number | bigint | string,
@@ -224,7 +224,7 @@ export function formatAlgoAmount(
 
   const formatOptions = { precision, trim, maxLength, compact, decimals: 6 }
 
-  return formatNumber(amount, formatOptions)
+  return formatAmount(amount, formatOptions)
 }
 
 /**


### PR DESCRIPTION
This consolidates all of the various number formatting functions so they are all based on `formatAmount`, and accepts its `options` object.

The `formatAmount` function itself (renamed from `formatNumber`) is refactored to use Big.js and accept numbers, bigints, or strings for the `amount`.