### PR TITLE
fix(ui): invalidate 'pools-info' query after box value is set

### DIFF
--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -13,7 +13,6 @@ import { fetchNfd } from '@/api/nfd'
 import { ALGORAND_ZERO_ADDRESS_STRING } from '@/constants/accounts'
 import { StakingPoolClient } from '@/contracts/StakingPoolClient'
 import { ValidatorRegistryClient } from '@/contracts/ValidatorRegistryClient'
-import { AlgodHttpError } from '@/interfaces/algod'
 import { StakedInfo, StakerPoolData, StakerValidatorData } from '@/interfaces/staking'
 import {
   Constraints,
@@ -1063,17 +1062,7 @@ export async function claimTokens(
 export async function fetchStakedInfoForPool(poolAppId: number): Promise<StakedInfo[]> {
   try {
     const stakingPoolClient = await getSimulateStakingPoolClient(poolAppId)
-
-    let boxValue: Uint8Array
-    try {
-      boxValue = await stakingPoolClient.appClient.getBoxValue('stakers')
-    } catch (error: unknown) {
-      if (error instanceof AlgodHttpError && error.response.status === 404) {
-        return []
-      } else {
-        throw error
-      }
-    }
+    const boxValue = await stakingPoolClient.appClient.getBoxValue('stakers')
 
     const stakersInfo = chunkBytes(boxValue)
       .map((stakerData) => transformStakedInfo(stakerData))

--- a/ui/src/components/AddPoolModal.tsx
+++ b/ui/src/components/AddPoolModal.tsx
@@ -205,8 +205,6 @@ export function AddPoolModal({
         duration: 5000,
       })
 
-      queryClient.invalidateQueries({ queryKey: ['pools-info', validator.id] })
-
       // Refetch account info to get new available balance for MBR payment
       await accountInfoQuery.refetch()
 
@@ -229,6 +227,10 @@ export function AddPoolModal({
     try {
       if (!activeAddress) {
         throw new Error('No active address')
+      }
+
+      if (!validator) {
+        throw new Error('No validator found')
       }
 
       if (!poolKey) {
@@ -264,6 +266,8 @@ export function AddPoolModal({
         id: toastId,
         duration: 5000,
       })
+
+      queryClient.invalidateQueries({ queryKey: ['pools-info', validator.id] })
 
       // Refetch validator data
       const newData = await fetchValidator(validator!.id)


### PR DESCRIPTION
In the add pool workflow, the 'pools-info' query was being invalidated after step 1 when the pool is still in the "limbo" state before the storage MBR is paid. That's why `fetchStakedInfoForPool` was throwing a 404 error: the 'stakers' box value has not been set yet.

This moves invalidation to step 2, after the box value has been set. No more error.

This PR also reverts the change in https://github.com/TxnLab/reti/pull/165