### PR TITLE
fix(ui): edit token payout converts amount to base units

### DIFF
--- a/ui/src/components/AddValidatorForm.tsx
+++ b/ui/src/components/AddValidatorForm.tsx
@@ -249,11 +249,15 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
         throw new Error('No active address')
       }
 
+      if (!rewardToken) {
+        throw new Error('No reward token entered')
+      }
+
       toast.loading('Sign transactions to add validator...', { id: toastId })
 
       const rewardPerPayout = convertToBaseUnits(
-        Number(values.rewardPerPayout),
-        Number(rewardToken?.params.decimals || 0),
+        values.rewardPerPayout,
+        rewardToken.params.decimals,
       )
 
       const epochRoundLength = getEpochLengthBlocks(

--- a/ui/src/components/ValidatorDetails/EditRewardPerPayout.tsx
+++ b/ui/src/components/ValidatorDetails/EditRewardPerPayout.tsx
@@ -21,6 +21,7 @@ import { Input } from '@/components/ui/input'
 import { EditValidatorModal } from '@/components/ValidatorDetails/EditValidatorModal'
 import { Validator } from '@/interfaces/validator'
 import { setValidatorQueriesData } from '@/utils/contracts'
+import { convertToBaseUnits } from '@/utils/format'
 import { validatorSchemas } from '@/utils/validation'
 
 interface EditRewardPerPayoutProps {
@@ -85,6 +86,15 @@ export function EditRewardPerPayout({ validator }: EditRewardPerPayoutProps) {
         throw new Error('No active address')
       }
 
+      if (!validator.rewardToken) {
+        throw new Error('No reward token found')
+      }
+
+      const rewardPerPayoutBaseUnits = convertToBaseUnits(
+        values.rewardPerPayout,
+        validator.rewardToken.params.decimals,
+      )
+
       toast.loading('Sign transactions to update reward amount per payout...', { id: toastId })
 
       await changeValidatorRewardInfo(
@@ -93,7 +103,7 @@ export function EditRewardPerPayout({ validator }: EditRewardPerPayoutProps) {
         entryGatingAddress,
         entryGatingAssets,
         gatingAssetMinBalance,
-        BigInt(values.rewardPerPayout),
+        BigInt(rewardPerPayoutBaseUnits),
         transactionSigner,
         activeAddress,
       )


### PR DESCRIPTION
This was updated in `AddValidatorForm` but not in the modal for editing reward token payout amount.

The amount entered should be in whole units (validation already supports this), and when the form is submitted the amount is converted to base units and passed to the `changeValidatorRewardInfo` method call.