### PR TITLE
fix(ui): convert current rewardPerPayout to whole units

### DIFF
--- a/ui/src/components/AddValidatorForm.tsx
+++ b/ui/src/components/AddValidatorForm.tsx
@@ -711,6 +711,7 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
                     <FormControl>
                       <Input placeholder="" {...field} />
                     </FormControl>
+                    <FormDescription>Enter amount in whole units (not base units)</FormDescription>
                     <FormMessage>{errors.rewardPerPayout?.message}</FormMessage>
                   </FormItem>
                 )}

--- a/ui/src/components/ValidatorDetails/EditRewardPerPayout.tsx
+++ b/ui/src/components/ValidatorDetails/EditRewardPerPayout.tsx
@@ -12,6 +12,7 @@ import { DialogFooter } from '@/components/ui/dialog'
 import {
   Form,
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -152,6 +153,7 @@ export function EditRewardPerPayout({ validator }: EditRewardPerPayoutProps) {
                   <FormControl>
                     <Input placeholder="" {...field} />
                   </FormControl>
+                  <FormDescription>Enter amount in whole units (not base units)</FormDescription>
                   <FormMessage>{errors.rewardPerPayout?.message}</FormMessage>
                 </FormItem>
               )}

--- a/ui/src/components/ValidatorDetails/EditRewardPerPayout.tsx
+++ b/ui/src/components/ValidatorDetails/EditRewardPerPayout.tsx
@@ -21,7 +21,7 @@ import { Input } from '@/components/ui/input'
 import { EditValidatorModal } from '@/components/ValidatorDetails/EditValidatorModal'
 import { Validator } from '@/interfaces/validator'
 import { setValidatorQueriesData } from '@/utils/contracts'
-import { convertToBaseUnits } from '@/utils/format'
+import { convertFromBaseUnits, convertToBaseUnits } from '@/utils/format'
 import { validatorSchemas } from '@/utils/validation'
 
 interface EditRewardPerPayoutProps {
@@ -47,8 +47,13 @@ export function EditRewardPerPayout({ validator }: EditRewardPerPayoutProps) {
     rewardPerPayout,
   } = validator.config
 
+  const rewardPerPayoutWholeUnits = convertFromBaseUnits(
+    rewardPerPayout,
+    validator.rewardToken?.params.decimals,
+  )
+
   const defaultValues = {
-    rewardPerPayout: String(Number(rewardPerPayout) || ''),
+    rewardPerPayout: String(rewardPerPayoutWholeUnits || ''),
   }
 
   const form = useForm<z.infer<typeof formSchema>>({

--- a/ui/src/components/ValidatorDetails/EditRewardPerPayout.tsx
+++ b/ui/src/components/ValidatorDetails/EditRewardPerPayout.tsx
@@ -47,10 +47,10 @@ export function EditRewardPerPayout({ validator }: EditRewardPerPayoutProps) {
     rewardPerPayout,
   } = validator.config
 
-  const rewardPerPayoutWholeUnits = convertFromBaseUnits(
-    rewardPerPayout,
-    validator.rewardToken?.params.decimals,
-  )
+  const tokenUnitName = validator.rewardToken?.params['unit-name']
+  const tokenDecimals = validator.rewardToken?.params.decimals
+
+  const rewardPerPayoutWholeUnits = convertFromBaseUnits(rewardPerPayout, tokenDecimals)
 
   const defaultValues = {
     rewardPerPayout: String(rewardPerPayoutWholeUnits || ''),
@@ -136,7 +136,7 @@ export function EditRewardPerPayout({ validator }: EditRewardPerPayoutProps) {
   return (
     <EditValidatorModal
       title="Edit Reward Per Payout"
-      description={`Set the amount of reward tokens paid out each epoch for Validator ${validator.id}`}
+      description={`Set the amount of ${tokenUnitName || 'reward tokens'} paid out each epoch for Validator ${validator.id}`}
       open={isOpen}
       onOpenChange={handleOpenChange}
     >

--- a/ui/src/components/ValidatorDetails/EditRewardPerPayout.tsx
+++ b/ui/src/components/ValidatorDetails/EditRewardPerPayout.tsx
@@ -96,7 +96,7 @@ export function EditRewardPerPayout({ validator }: EditRewardPerPayoutProps) {
         throw new Error('No reward token found')
       }
 
-      const rewardPerPayoutBaseUnits = convertToBaseUnits(
+      const newRewardPerPayoutBaseUnits = convertToBaseUnits(
         values.rewardPerPayout,
         validator.rewardToken.params.decimals,
       )
@@ -109,7 +109,7 @@ export function EditRewardPerPayout({ validator }: EditRewardPerPayoutProps) {
         entryGatingAddress,
         entryGatingAssets,
         gatingAssetMinBalance,
-        BigInt(rewardPerPayoutBaseUnits),
+        BigInt(newRewardPerPayoutBaseUnits),
         transactionSigner,
         activeAddress,
       )


### PR DESCRIPTION
When the `EditRewardPerPayout` modal opens, the input is pre-populated with the current value for `rewardPerPayout`, which can then be edited.

The form expects this value to be in whole units, but the initial value was the raw base unit value from the validator config.

This correctly converts the initial value to its whole unit amount. If that value is edited, it is converted back to base units before it is submitted.

### Other Changes
In both the `EditRewardPerPayout` modal and the `AddValidatorForm`, a description now instructs the user to enter whole unit amounts. They should only ever think of reward token amounts in terms of whole units.

This also updates the `EditRewardPerPayout` modal description to show the unit name of the reward token, e.g., "Set the amount of PEPE paid out each epoch for Validator 10".