### PR TITLE
fix(ui): don't mutate cached params in addValidator

### DIFF
--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -218,10 +218,13 @@ export async function addValidator(
       .simulate({ allowEmptySignatures: true, allowUnnamedResources: true })
   ).returns![0]
 
-  const suggestedParams = await ParamsCache.getSuggestedParams()
+  const params = await ParamsCache.getSuggestedParams()
 
-  suggestedParams.flatFee = true
-  suggestedParams.fee = AlgoAmount.Algos(10.001).microAlgos
+  const suggestedParams = {
+    ...params,
+    flatFee: true,
+    fee: AlgoAmount.Algos(10.001).microAlgos,
+  }
 
   const payValidatorMbr = algosdk.makePaymentTxnWithSuggestedParamsFromObject({
     from: activeAddress,


### PR DESCRIPTION
In `addValidator`, we fetch the suggested params from the params cache then need to set `flatFee` and `fee` before using them to pay the validator MBR.

By mutating the object's properties directly, the values set are then being used everywhere we fetch cached params in subsequent transactions (until fresh data is refetched).

This updates that step to change the properties immutably, by creating a new object, spreading the cached params into it, and updating that object's properties.