### PR TITLE
fix(ui): fix AddValidatorForm onSubmit regression (error if no token set)

### DIFF
--- a/ui/src/components/AddValidatorForm.tsx
+++ b/ui/src/components/AddValidatorForm.tsx
@@ -249,15 +249,11 @@ export function AddValidatorForm({ constraints }: AddValidatorFormProps) {
         throw new Error('No active address')
       }
 
-      if (!rewardToken) {
-        throw new Error('No reward token entered')
-      }
-
       toast.loading('Sign transactions to add validator...', { id: toastId })
 
       const rewardPerPayout = convertToBaseUnits(
-        values.rewardPerPayout,
-        rewardToken.params.decimals,
+        Number(values.rewardPerPayout),
+        rewardToken?.params.decimals || 0,
       )
 
       const epochRoundLength = getEpochLengthBlocks(


### PR DESCRIPTION
An error was added to handle `rewardToken` being null when converting `values.rewardPerPayout` to base units. It now uses optional chaining with a fallback instead.