### PR TITLE
fix(ui): pressing Enter should submit add/remove stake form

### DIFF
--- a/ui/src/components/AddStakeModal.tsx
+++ b/ui/src/components/AddStakeModal.tsx
@@ -523,6 +523,7 @@ export function AddStakeModal({
                           }}
                         />
                         <Button
+                          type="button"
                           size="sm"
                           variant="outline"
                           className="absolute inset-y-1 right-1.5 h-7 px-2 flex items-center text-muted-foreground text-xs uppercase"

--- a/ui/src/components/UnstakeModal.tsx
+++ b/ui/src/components/UnstakeModal.tsx
@@ -302,6 +302,7 @@ export function UnstakeModal({ validator, setValidator, stakesByValidator }: Uns
                           <div className="relative">
                             <Input className="pr-16" {...field} />
                             <Button
+                              type="button"
                               size="sm"
                               variant="outline"
                               className="absolute inset-y-1 right-1.5 h-7 px-2 flex items-center text-muted-foreground text-xs uppercase"


### PR DESCRIPTION
Pressing Enter in `AddStakeModal` or `UnstakeModal` calls the function to set the maximum amount instead of submitting the form.

This adds `type="button"` to the MAX button to prevent it from catching the keypress event.