### PR TITLE
fix(ui): add 2nd gas call to addStake

### DIFF
--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -544,7 +544,8 @@ export async function addStake(
 
   const simulateComposer = simulateValidatorClient
     .compose()
-    .gas({})
+    .gas({}, { note: '1', sendParams: { fee: AlgoAmount.MicroAlgos(0) } })
+    .gas({}, { note: '2', sendParams: { fee: AlgoAmount.MicroAlgos(0) } })
     .addStake(
       {
         stakedAmountPayment: {
@@ -578,12 +579,13 @@ export async function addStake(
 
   // @todo: switch to Joe's new method(s)
   const feeAmount = AlgoAmount.MicroAlgos(
-    2000 + 1000 * ((simulateResults.simulateResponse.txnGroups[0].appBudgetAdded as number) / 700),
+    3000 + 1000 * ((simulateResults.simulateResponse.txnGroups[0].appBudgetAdded as number) / 700),
   )
 
   const composer = validatorClient
     .compose()
-    .gas({})
+    .gas({}, { note: '1', sendParams: { fee: AlgoAmount.MicroAlgos(0) } })
+    .gas({}, { note: '2', sendParams: { fee: AlgoAmount.MicroAlgos(0) } })
     .addStake(
       {
         stakedAmountPayment: {
@@ -610,7 +612,7 @@ export async function addStake(
 
   const result = await composer.execute({ populateAppCallResources: true })
 
-  const [valId, poolId, poolAppId] = result.returns![1]
+  const [valId, poolId, poolAppId] = result.returns![2]
 
   return {
     poolId: Number(poolId),


### PR DESCRIPTION
This increases opcode budget, fixing failed `addStake` app calls for validators with NFD segment entry gating.