### PR TITLE
feat(ui): AddValidatorForm entry gating updates

### DIFF
--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -12,8 +12,10 @@ import {
 } from '@/api/clients'
 import { fetchNfd } from '@/api/nfd'
 import { ALGORAND_ZERO_ADDRESS_STRING } from '@/constants/accounts'
+import { GatingType } from '@/constants/gating'
 import { StakingPoolClient } from '@/contracts/StakingPoolClient'
 import { ValidatorRegistryClient } from '@/contracts/ValidatorRegistryClient'
+import { Asset } from '@/interfaces/algod'
 import { StakedInfo, StakerPoolData, StakerValidatorData } from '@/interfaces/staking'
 import {
   Constraints,
@@ -121,6 +123,19 @@ export async function fetchValidator(
     if (validator.config.rewardTokenId > 0) {
       const rewardToken = await fetchAsset(validator.config.rewardTokenId)
       validator.rewardToken = rewardToken
+    }
+
+    if (validator.config.entryGatingType === GatingType.AssetId) {
+      const gatingAssets = await Promise.all(
+        validator.config.entryGatingAssets.map(async (assetId) => {
+          if (assetId > 0) {
+            return fetchAsset(assetId)
+          }
+          return null
+        }),
+      )
+
+      validator.gatingAssets = gatingAssets.filter(Boolean) as Asset[]
     }
 
     if (validator.config.nfdForInfo > 0) {

--- a/ui/src/components/AddPoolModal.tsx
+++ b/ui/src/components/AddPoolModal.tsx
@@ -17,10 +17,10 @@ import {
 } from '@/api/contracts'
 import { mbrQueryOptions, poolAssignmentQueryOptions } from '@/api/queries'
 import { AlgoDisplayAmount } from '@/components/AlgoDisplayAmount'
+import { DisplayAsset } from '@/components/DisplayAsset'
 import { NfdLookup } from '@/components/NfdLookup'
 import { NfdThumbnail } from '@/components/NfdThumbnail'
 import { NodeSelect } from '@/components/NodeSelect'
-import { RewardToken } from '@/components/RewardToken'
 import { Button } from '@/components/ui/button'
 import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible'
 import {
@@ -512,8 +512,8 @@ export function AddPoolModal({
                     <CollapsibleContent className="space-y-2">
                       <div>
                         <p className="text-sm text-muted-foreground mb-2">
-                          You can now send <RewardToken validator={validator} link /> tokens to Pool
-                          1.
+                          You can now send <DisplayAsset asset={validator?.rewardToken} link />{' '}
+                          tokens to Pool 1.
                         </p>
                         <p className="text-sm text-muted-foreground mb-4">
                           Tokens will be distributed from this pool every epoch based on the

--- a/ui/src/components/AssetLookup.tsx
+++ b/ui/src/components/AssetLookup.tsx
@@ -1,4 +1,5 @@
 import { Check } from 'lucide-react'
+import * as React from 'react'
 import { FieldPath, FieldValues, UseFormReturn } from 'react-hook-form'
 import { useDebouncedCallback } from 'use-debounce'
 import { fetchAsset as fetchAssetInformation } from '@/api/algod'
@@ -86,6 +87,16 @@ export function AssetLookup<
       setIsFetching(false)
     }
   }, 500)
+
+  React.useEffect(() => {
+    const initialFetch = async () => {
+      if (form.getValues(name)) {
+        await fetchAsset(form.getValues(name))
+      }
+    }
+
+    initialFetch()
+  }, [])
 
   const renderLabel = () => {
     if (typeof label === 'string') {

--- a/ui/src/components/AssetLookup.tsx
+++ b/ui/src/components/AssetLookup.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { AlgodHttpError, Asset } from '@/interfaces/algod'
 import { cn } from '@/utils/ui'
 
+const ERROR_EMPTY_FIELD = 'No asset ID entered'
 const ERROR_NOT_FOUND = 'Asset not found'
 const ERROR_FAILED = 'Failed to fetch asset'
 const ERROR_UNKNOWN = 'An unknown error occurred'
@@ -22,7 +23,7 @@ interface AssetLookupProps<
   isFetching: boolean
   setIsFetching: (isFetching: boolean) => void
   errorMessage?: string
-  label?: string
+  label?: React.ReactNode
   className?: string
 }
 
@@ -42,6 +43,12 @@ export function AssetLookup<
 }: AssetLookupProps<TFieldValues, TName>) {
   const fetchAsset = async (value: string) => {
     try {
+      if (!value) {
+        // If the field is empty, set a validation error but don't throw an error
+        form.setError(name, { type: 'manual', message: ERROR_EMPTY_FIELD })
+        return
+      }
+
       const asset = await fetchAssetInformation(Number(value))
 
       form.clearErrors(name)
@@ -80,13 +87,25 @@ export function AssetLookup<
     }
   }, 500)
 
+  const renderLabel = () => {
+    if (typeof label === 'string') {
+      return <FormLabel>{label}</FormLabel>
+    }
+
+    if (label) {
+      return label
+    }
+
+    return null
+  }
+
   return (
     <FormField
       control={form.control}
       name={name}
       render={({ field }) => (
         <FormItem className={className}>
-          {label && <FormLabel>{label}</FormLabel>}
+          {renderLabel()}
           <div className="flex items-center gap-x-3">
             <div className="flex-1 relative">
               <FormControl>

--- a/ui/src/components/DisplayAsset.tsx
+++ b/ui/src/components/DisplayAsset.tsx
@@ -1,35 +1,29 @@
 import * as React from 'react'
-import { Validator } from '@/interfaces/validator'
+import { Asset } from '@/interfaces/algod'
 import { ExplorerLink } from '@/utils/explorer'
 import { cn } from '@/utils/ui'
 
-interface RewardTokenProps {
-  validator?: Validator | null
+interface DisplayAssetProps {
+  asset?: Asset
   show?: 'name' | 'unit-name' | 'full'
   link?: boolean
   fallback?: React.ReactNode
   className?: string
 }
 
-export function RewardToken({
-  validator,
+export function DisplayAsset({
+  asset,
   show = 'unit-name',
   link = false,
   fallback = <span className="text-muted-foreground">--</span>,
   className = '',
-}: RewardTokenProps) {
+}: DisplayAssetProps) {
   const renderUnitName = (unitName: string) => {
     return <span className="font-mono">{unitName}</span>
   }
 
-  const renderRewardToken = (validator: Validator) => {
-    const { rewardToken } = validator
-
-    if (!rewardToken) {
-      return validator.config.rewardTokenId
-    }
-
-    const { name, 'unit-name': unitName } = rewardToken.params
+  const renderDisplayAsset = (asset: Asset) => {
+    const { name, 'unit-name': unitName } = asset.params
 
     if (unitName && show === 'unit-name') {
       return renderUnitName(unitName)
@@ -57,25 +51,25 @@ export function RewardToken({
       return renderUnitName(unitName)
     }
 
-    return validator.config.rewardTokenId
+    return asset.index
   }
 
-  if (!validator?.config.rewardTokenId) {
+  if (!asset) {
     return fallback
   }
 
   if (link) {
     return (
       <a
-        href={ExplorerLink.asset(validator.config.rewardTokenId)}
+        href={ExplorerLink.asset(asset.index)}
         rel="noreferrer"
         target="_blank"
         className={cn('link text-foreground', className)}
       >
-        {renderRewardToken(validator)}
+        {renderDisplayAsset(asset)}
       </a>
     )
   }
 
-  return <span className={className}>{renderRewardToken(validator)}</span>
+  return <span className={className}>{renderDisplayAsset(asset)}</span>
 }

--- a/ui/src/components/StakingTable.tsx
+++ b/ui/src/components/StakingTable.tsx
@@ -116,7 +116,7 @@ export function StakingTable({
               params={{
                 validatorId: String(row.original.validatorId),
               }}
-              className="hover:underline underline-offset-4"
+              className="link underline-offset-4"
             >
               {nfdAppId > 0 ? (
                 <NfdThumbnail nameOrId={nfdAppId} />

--- a/ui/src/components/ValidatorDetails/Details.tsx
+++ b/ui/src/components/ValidatorDetails/Details.tsx
@@ -17,7 +17,7 @@ import { useRewardBalance } from '@/hooks/useRewardBalance'
 import { dayjs } from '@/utils/dayjs'
 import { ellipseAddressJsx } from '@/utils/ellipseAddress'
 import { ExplorerLink } from '@/utils/explorer'
-import { formatAmount, formatAssetAmount } from '@/utils/format'
+import { convertFromBaseUnits, formatAmount, formatAssetAmount } from '@/utils/format'
 import { getNfdAppFromViteEnvironment } from '@/utils/network/getNfdConfig'
 
 const nfdAppUrl = getNfdAppFromViteEnvironment()
@@ -94,24 +94,16 @@ export function Details({ validator }: DetailsProps) {
             </a>
           </>
         )
-      // @todo: Fetch gating assets and display unit names
       case GatingType.AssetId:
         return (
           <>
-            <strong className="font-medium text-muted-foreground">Asset ID</strong>
-            <ul className="mt-1 list-none list-inside">
+            <strong className="font-medium text-muted-foreground">Asset(s)</strong>
+            <ul className="mt-1 list-none">
               {entryGatingAssets
                 .filter((assetId) => assetId !== 0)
-                .map((assetId) => (
-                  <li key={assetId}>
-                    <a
-                      href={ExplorerLink.asset(assetId)}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="font-mono hover:underline"
-                    >
-                      {assetId}
-                    </a>
+                .map((assetId, index) => (
+                  <li key={assetId} className="leading-loose">
+                    <DisplayAsset asset={validator.gatingAssets?.[index]} link />
                   </li>
                 ))}
             </ul>
@@ -150,14 +142,14 @@ export function Details({ validator }: DetailsProps) {
           <div className="border-t border-foreground-muted">
             <dl className="divide-y divide-foreground-muted">
               <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                <dt className="text-sm font-medium leading-6 text-muted-foreground">
+                <dt className="text-sm font-medium leading-normal text-muted-foreground">
                   Validator ID
                 </dt>
-                <dd className="flex items-center gap-x-2 text-sm leading-6">{validator.id}</dd>
+                <dd className="flex items-center gap-x-2 text-sm leading-normal">{validator.id}</dd>
               </div>
               <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                <dt className="text-sm font-medium leading-6 text-muted-foreground">Owner</dt>
-                <dd className="flex items-center justify-between gap-x-2 text-sm font-mono leading-6">
+                <dt className="text-sm font-medium leading-normal text-muted-foreground">Owner</dt>
+                <dd className="flex items-center justify-between gap-x-2 text-sm font-mono leading-normal">
                   <a
                     href={ExplorerLink.account(validator.config.owner)}
                     target="_blank"
@@ -169,10 +161,10 @@ export function Details({ validator }: DetailsProps) {
                 </dd>
               </div>
               <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                <dt className="flex items-center text-sm font-medium leading-6 text-muted-foreground">
+                <dt className="flex items-center text-sm font-medium leading-normal text-muted-foreground">
                   Manager
                 </dt>
-                <dd className="flex items-center justify-between gap-x-2 text-sm font-mono leading-6">
+                <dd className="flex items-center justify-between gap-x-2 text-sm font-mono leading-normal">
                   <a
                     href={ExplorerLink.account(validator.config.manager)}
                     target="_blank"
@@ -185,10 +177,10 @@ export function Details({ validator }: DetailsProps) {
                 </dd>
               </div>
               <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                <dt className="flex items-center text-sm font-medium leading-6 text-muted-foreground">
+                <dt className="flex items-center text-sm font-medium leading-normal text-muted-foreground">
                   Commission Account
                 </dt>
-                <dd className="flex items-center justify-between gap-x-2 text-sm font-mono leading-6">
+                <dd className="flex items-center justify-between gap-x-2 text-sm font-mono leading-normal">
                   <a
                     href={ExplorerLink.account(validator.config.validatorCommissionAddress)}
                     target="_blank"
@@ -203,10 +195,10 @@ export function Details({ validator }: DetailsProps) {
 
               {(isOwner || validator.nfd) && (
                 <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                  <dt className="flex items-center text-sm font-medium leading-6 text-muted-foreground">
+                  <dt className="flex items-center text-sm font-medium leading-normal text-muted-foreground">
                     Associated NFD
                   </dt>
-                  <dd className="flex items-center justify-between gap-x-2 text-sm font-medium leading-6">
+                  <dd className="flex items-center justify-between gap-x-2 text-sm font-medium leading-normal">
                     {validator.nfd ? (
                       <Tooltip content={validator.nfd.name}>
                         <a
@@ -227,10 +219,10 @@ export function Details({ validator }: DetailsProps) {
               )}
 
               <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                <dt className="text-sm font-medium leading-6 text-muted-foreground">
+                <dt className="text-sm font-medium leading-normal text-muted-foreground">
                   Minimum Entry Stake
                 </dt>
-                <dd className="flex items-center justify-between gap-x-2 text-sm leading-6">
+                <dd className="flex items-center justify-between gap-x-2 text-sm leading-normal">
                   <AlgoDisplayAmount
                     amount={validator.config.minEntryStake}
                     microalgos
@@ -239,28 +231,28 @@ export function Details({ validator }: DetailsProps) {
                 </dd>
               </div>
               <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                <dt className="text-sm font-medium leading-6 text-muted-foreground">
+                <dt className="text-sm font-medium leading-normal text-muted-foreground">
                   Epoch Length
                 </dt>
-                <dd className="flex items-center justify-between gap-x-2 text-sm leading-6">
+                <dd className="flex items-center justify-between gap-x-2 text-sm leading-normal">
                   <span className="capitalize">
                     {formatAmount(validator.config.epochRoundLength)} blocks
                   </span>
                 </dd>
               </div>
               <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                <dt className="text-sm font-medium leading-6 text-muted-foreground">
+                <dt className="text-sm font-medium leading-normal text-muted-foreground">
                   Commission Rate
                 </dt>
-                <dd className="flex items-center justify-between gap-x-2 text-sm leading-6">
+                <dd className="flex items-center justify-between gap-x-2 text-sm leading-normal">
                   {`${validator.config.percentToValidator / 10000}%`}
                 </dd>
               </div>
               <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                <dt className="text-sm font-medium leading-6 text-muted-foreground">
+                <dt className="text-sm font-medium leading-normal text-muted-foreground">
                   Pools Per Node
                 </dt>
-                <dd className="flex items-center justify-between gap-x-2 text-sm leading-6">
+                <dd className="flex items-center justify-between gap-x-2 text-sm leading-normal">
                   {validator.config.poolsPerNode}
                 </dd>
               </div>
@@ -268,18 +260,18 @@ export function Details({ validator }: DetailsProps) {
               {validator.config.rewardTokenId > 0 && (
                 <>
                   <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                    <dt className="text-sm font-medium leading-6 text-muted-foreground">
+                    <dt className="text-sm font-medium leading-normal text-muted-foreground">
                       Reward Token
                     </dt>
-                    <dd className="flex items-center justify-between gap-x-2 text-sm leading-6">
+                    <dd className="flex items-center justify-between gap-x-2 text-sm leading-normal">
                       <DisplayAsset asset={validator.rewardToken} show="full" link />
                     </dd>
                   </div>
                   <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                    <dt className="text-sm font-medium leading-6 text-muted-foreground">
+                    <dt className="text-sm font-medium leading-normal text-muted-foreground">
                       Reward Per Payout
                     </dt>
-                    <dd className="flex items-center justify-between gap-x-2 text-sm leading-6">
+                    <dd className="flex items-center justify-between gap-x-2 text-sm leading-normal">
                       {renderRewardPerPayout()}
                       {isOwner && validator.config.rewardTokenId > 0 && (
                         <EditRewardPerPayout validator={validator} />
@@ -287,10 +279,10 @@ export function Details({ validator }: DetailsProps) {
                     </dd>
                   </div>
                   <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                    <dt className="text-sm font-medium leading-6 text-muted-foreground">
+                    <dt className="text-sm font-medium leading-normal text-muted-foreground">
                       Reward Token Balance
                     </dt>
-                    <dd className="flex items-center justify-between gap-x-2 text-sm leading-6">
+                    <dd className="flex items-center justify-between gap-x-2 text-sm leading-normal">
                       {renderRewardBalance()}
                     </dd>
                   </div>
@@ -300,10 +292,10 @@ export function Details({ validator }: DetailsProps) {
               {(isOwner || validator.config.entryGatingType > 0) && (
                 <>
                   <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                    <dt className="text-sm font-medium leading-6 text-muted-foreground">
+                    <dt className="text-sm font-medium leading-normal text-muted-foreground">
                       Entry Gating
                     </dt>
-                    <dd className="flex items-center justify-between gap-x-2 text-sm leading-6">
+                    <dd className="flex items-center justify-between gap-x-2 text-sm leading-normal">
                       {validator.config.entryGatingType === 0 ? (
                         <span className="text-muted-foreground">--</span>
                       ) : (
@@ -313,16 +305,21 @@ export function Details({ validator }: DetailsProps) {
                     </dd>
                   </div>
 
-                  {/* @todo: convertFromBaseUnits each asset's min balance and display unit name */}
-                  {![GatingType.None, GatingType.SegmentNfd].includes(
-                    validator.config.entryGatingType,
-                  ) && (
+                  {validator.config.gatingAssetMinBalance > 1 && !!validator.gatingAssets?.[0] && (
                     <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                      <dt className="text-sm font-medium leading-6 text-muted-foreground">
+                      <dt className="text-sm font-medium leading-normal text-muted-foreground">
                         Gating Asset Minimum Balance
                       </dt>
-                      <dd className="flex items-center justify-between gap-x-2 text-sm font-mono leading-6">
-                        {formatAmount(validator.config.gatingAssetMinBalance.toString())}
+                      <dd className="flex items-center justify-between gap-x-2 text-sm font-mono leading-normal">
+                        <span>
+                          {formatAmount(
+                            convertFromBaseUnits(
+                              validator.config.gatingAssetMinBalance,
+                              validator.gatingAssets[0].params.decimals || 0,
+                            ),
+                          )}{' '}
+                          <DisplayAsset asset={validator.gatingAssets[0]} />
+                        </span>
                       </dd>
                     </div>
                   )}
@@ -331,10 +328,10 @@ export function Details({ validator }: DetailsProps) {
 
               {isOwner || validator.config.sunsettingOn ? (
                 <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">
-                  <dt className="text-sm font-medium leading-6 text-muted-foreground">
+                  <dt className="text-sm font-medium leading-normal text-muted-foreground">
                     Sunset Date
                   </dt>
-                  <dd className="flex items-center justify-between gap-x-2 text-sm leading-6">
+                  <dd className="flex items-center justify-between gap-x-2 text-sm leading-normal">
                     {validator.config.sunsettingOn === 0 ? (
                       <span className="text-muted-foreground">--</span>
                     ) : (

--- a/ui/src/components/ValidatorDetails/Details.tsx
+++ b/ui/src/components/ValidatorDetails/Details.tsx
@@ -1,8 +1,8 @@
 import { useWallet } from '@txnlab/use-wallet-react'
 import { AlgoDisplayAmount } from '@/components/AlgoDisplayAmount'
+import { DisplayAsset } from '@/components/DisplayAsset'
 import { Loading } from '@/components/Loading'
 import { NfdThumbnail } from '@/components/NfdThumbnail'
-import { RewardToken } from '@/components/RewardToken'
 import { Tooltip } from '@/components/Tooltip'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { EditCommissionAccount } from '@/components/ValidatorDetails/EditCommissionAccount'
@@ -272,7 +272,7 @@ export function Details({ validator }: DetailsProps) {
                       Reward Token
                     </dt>
                     <dd className="flex items-center justify-between gap-x-2 text-sm leading-6">
-                      <RewardToken validator={validator} show="full" link />
+                      <DisplayAsset asset={validator.rewardToken} show="full" link />
                     </dd>
                   </div>
                   <div className="py-4 grid grid-cols-[2fr_3fr] gap-4 xl:grid-cols-2">

--- a/ui/src/components/ValidatorDetails/EditValidatorModal.tsx
+++ b/ui/src/components/ValidatorDetails/EditValidatorModal.tsx
@@ -8,12 +8,14 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
+import { cn } from '@/utils/ui'
 
 interface EditValidatorModalProps {
   title: string
   description: string
   open: boolean
   onOpenChange: (open: boolean) => void
+  className?: string
   children?: React.ReactNode
 }
 
@@ -22,6 +24,7 @@ export function EditValidatorModal({
   description,
   open,
   onOpenChange,
+  className = '',
   children,
 }: EditValidatorModalProps) {
   return (
@@ -36,7 +39,7 @@ export function EditValidatorModal({
             <Settings2 className="h-5 w-5" />
           </Button>
         </DialogTrigger>
-        <DialogContent className="max-w-[600px]">
+        <DialogContent className={cn('max-w-[640px]', className)}>
           <DialogHeader>
             <DialogTitle>{title}</DialogTitle>
             <DialogDescription>{description}</DialogDescription>

--- a/ui/src/components/ValidatorInfoRow.tsx
+++ b/ui/src/components/ValidatorInfoRow.tsx
@@ -1,4 +1,4 @@
-import { RewardToken } from '@/components/RewardToken'
+import { DisplayAsset } from '@/components/DisplayAsset'
 import { useBlockTime } from '@/hooks/useBlockTime'
 import { Constraints, Validator } from '@/interfaces/validator'
 import { calculateMaxStakers } from '@/utils/contracts'
@@ -87,7 +87,7 @@ export function ValidatorInfoRow({ validator, constraints }: ValidatorInfoRowPro
         <div>
           <h4 className="text-sm font-medium text-muted-foreground">Reward Token</h4>
           <p className="text-sm">
-            <RewardToken validator={validator} show="name" />
+            <DisplayAsset asset={validator.rewardToken} show="name" />
           </p>
         </div>
         <div>

--- a/ui/src/components/ValidatorTable.tsx
+++ b/ui/src/components/ValidatorTable.tsx
@@ -163,7 +163,7 @@ export function ValidatorTable({
               params={{
                 validatorId: String(validator.id),
               }}
-              className="truncate hover:underline underline-offset-4"
+              className={cn('link underline-offset-4', { truncate: !!nfd })}
               preload="intent"
             >
               {nfd ? (

--- a/ui/src/interfaces/validator.ts
+++ b/ui/src/interfaces/validator.ts
@@ -87,6 +87,7 @@ export type Validator = {
   pools: PoolInfo[]
   nodePoolAssignment: NodePoolAssignmentConfig
   rewardToken?: Asset
+  gatingAssets?: Asset[]
   nfd?: Nfd
   apy?: number
 }

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -225,15 +225,20 @@ export function getEpochLengthBlocks(
   }
 }
 
+interface TransformedGatingAssets {
+  entryGatingAssets: string[]
+  gatingAssetMinBalance: string
+}
+
 /**
- * Transform entry gating assets into a fixed length array of asset IDs
+ * Prepares entry gating assets and minimum balance to submit to the contract
  * @param {string} type - Entry gating type
  * @param {Array<{ value: string }>} assetIds - Entry gating asset IDs from form input
  * @param {Array<Asset | null>} assets - Array of fetched asset objects
  * @param {string} minBalance - Minimum balance required for gating assets
  * @param {number} nfdCreatorAppId - NFD creator app ID
  * @param {number} nfdParentAppId - NFD parent app ID
- * @returns {string[]} Fixed length array of asset IDs
+ * @returns {TransformedGatingAssets} Gating assets and minimum balance prepared for submission
  */
 export function transformEntryGatingAssets(
   type: string,
@@ -242,7 +247,7 @@ export function transformEntryGatingAssets(
   minBalance: string,
   nfdCreatorAppId: number,
   nfdParentAppId: number,
-): { entryGatingAssets: string[]; gatingAssetMinBalance: string } {
+): TransformedGatingAssets {
   const fixedLengthArray: string[] = new Array(4).fill('0')
 
   switch (type) {

--- a/ui/src/utils/contracts.ts
+++ b/ui/src/utils/contracts.ts
@@ -3,7 +3,7 @@ import algosdk from 'algosdk'
 import { fetchAccountAssetInformation, fetchAccountInformation } from '@/api/algod'
 import { fetchNfd, fetchNfdSearch } from '@/api/nfd'
 import { GatingType } from '@/constants/gating'
-import { AssetHolding } from '@/interfaces/algod'
+import { Asset, AssetHolding } from '@/interfaces/algod'
 import { NfdSearchV2Params } from '@/interfaces/nfd'
 import { StakedInfo, StakerValidatorData } from '@/interfaces/staking'
 import {
@@ -21,6 +21,7 @@ import {
   ValidatorState,
 } from '@/interfaces/validator'
 import { dayjs } from '@/utils/dayjs'
+import { convertToBaseUnits } from '@/utils/format'
 
 /**
  * Transform raw validator configuration data (from `callGetValidatorConfig`) into a structured object
@@ -227,31 +228,55 @@ export function getEpochLengthBlocks(
 /**
  * Transform entry gating assets into a fixed length array of asset IDs
  * @param {string} type - Entry gating type
- * @param {Array<{ value: string }>} assets - Entry gating assets
+ * @param {Array<{ value: string }>} assetIds - Entry gating asset IDs from form input
+ * @param {Array<Asset | null>} assets - Array of fetched asset objects
+ * @param {string} minBalance - Minimum balance required for gating assets
  * @param {number} nfdCreatorAppId - NFD creator app ID
  * @param {number} nfdParentAppId - NFD parent app ID
  * @returns {string[]} Fixed length array of asset IDs
  */
 export function transformEntryGatingAssets(
   type: string,
-  assets: Array<{ value: string }>,
+  assetIds: Array<{ value: string }>,
+  assets: Array<Asset | null>,
+  minBalance: string,
   nfdCreatorAppId: number,
   nfdParentAppId: number,
-): string[] {
+): { entryGatingAssets: string[]; gatingAssetMinBalance: string } {
   const fixedLengthArray: string[] = new Array(4).fill('0')
 
   switch (type) {
     case String(GatingType.AssetId):
-      for (let i = 0; i < assets.length && i < 4; i++) {
-        fixedLengthArray[i] = assets[i].value !== '' ? assets[i].value : '0'
+      for (let i = 0; i < assetIds.length && i < 4; i++) {
+        fixedLengthArray[i] = assetIds[i].value !== '' ? assetIds[i].value : '0'
       }
-      return fixedLengthArray.sort((a, b) => Number(b) - Number(a))
+
+      if (minBalance !== '' && !assets[0]) {
+        throw new Error('Missing asset decimals for calculating minimum balance.')
+      }
+
+      return {
+        entryGatingAssets: fixedLengthArray.sort((a, b) => Number(b) - Number(a)),
+        gatingAssetMinBalance:
+          minBalance === '' || assetIds.length > 1
+            ? '1'
+            : convertToBaseUnits(minBalance, assets[0]!.params.decimals).toString(),
+      }
     case String(GatingType.CreatorNfd):
-      return [nfdCreatorAppId.toString(), '0', '0', '0']
+      return {
+        entryGatingAssets: [nfdCreatorAppId.toString(), '0', '0', '0'],
+        gatingAssetMinBalance: '1',
+      }
     case String(GatingType.SegmentNfd):
-      return [nfdParentAppId.toString(), '0', '0', '0']
+      return {
+        entryGatingAssets: [nfdParentAppId.toString(), '0', '0', '0'],
+        gatingAssetMinBalance: '1',
+      }
     default:
-      return fixedLengthArray
+      return {
+        entryGatingAssets: ['0', '0', '0', '0'],
+        gatingAssetMinBalance: '0',
+      }
   }
 }
 

--- a/ui/src/utils/validation.ts
+++ b/ui/src/utils/validation.ts
@@ -300,25 +300,25 @@ export const entryGatingRefinement = (
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingAddress'],
-          message: 'entryGatingAddress should not be set when entry gating is disabled',
+          message: 'entryGatingAddress should not be set when entryGatingType is None',
         })
       } else if (entryGatingAssets.length > 1 || entryGatingAssets[0].value !== '') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingAssets'],
-          message: 'entryGatingAssets should not be set when entry gating is disabled',
+          message: 'entryGatingAssets should not be set when entryGatingType is None',
         })
       } else if (entryGatingNfdCreator !== '') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingNfdCreator'],
-          message: 'entryGatingNfdCreator should not be set when entry gating is disabled',
+          message: 'entryGatingNfdCreator should not be set when entryGatingType is None',
         })
       } else if (entryGatingNfdParent !== '') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingNfdParent'],
-          message: 'entryGatingNfdParent should not be set when entry gating is disabled',
+          message: 'entryGatingNfdParent should not be set when entryGatingType is None',
         })
       }
       break
@@ -333,19 +333,19 @@ export const entryGatingRefinement = (
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingAssets'],
-          message: 'entryGatingAssets should not be set when entryGatingType is 1',
+          message: 'entryGatingAssets should not be set when entryGatingType is CreatorAccount',
         })
       } else if (entryGatingNfdCreator !== '') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingNfdCreator'],
-          message: 'entryGatingNfdCreator should not be set when entryGatingType is 1',
+          message: 'entryGatingNfdCreator should not be set when entryGatingType is CreatorAccount',
         })
       } else if (entryGatingNfdParent !== '') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingNfdParent'],
-          message: 'entryGatingNfdParent should not be set when entryGatingType is 1',
+          message: 'entryGatingNfdParent should not be set when entryGatingType is CreatorAccount',
         })
       }
       break
@@ -372,19 +372,19 @@ export const entryGatingRefinement = (
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingAddress'],
-          message: 'entryGatingAddress should not be set when entryGatingType is 2',
+          message: 'entryGatingAddress should not be set when entryGatingType is AssetId',
         })
       } else if (entryGatingNfdCreator !== '') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingNfdCreator'],
-          message: 'entryGatingNfdCreator should not be set when entryGatingType is 2',
+          message: 'entryGatingNfdCreator should not be set when entryGatingType is AssetId',
         })
       } else if (entryGatingNfdParent !== '') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingNfdParent'],
-          message: 'entryGatingNfdParent should not be set when entryGatingType is 2',
+          message: 'entryGatingNfdParent should not be set when entryGatingType is AssetId',
         })
       }
       break
@@ -393,19 +393,19 @@ export const entryGatingRefinement = (
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingAddress'],
-          message: 'entryGatingAddress should not be set when entryGatingType is 3',
+          message: 'entryGatingAddress should not be set when entryGatingType is CreatorNfd',
         })
       } else if (entryGatingAssets.length > 1 || entryGatingAssets[0].value !== '') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingAssets'],
-          message: 'entryGatingAssets should not be set when entryGatingType is 3',
+          message: 'entryGatingAssets should not be set when entryGatingType is CreatorNfd',
         })
       } else if (entryGatingNfdParent !== '') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingNfdParent'],
-          message: 'entryGatingNfdParent should not be set when entryGatingType is 3',
+          message: 'entryGatingNfdParent should not be set when entryGatingType is CreatorNfd',
         })
       }
       break
@@ -414,19 +414,19 @@ export const entryGatingRefinement = (
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingAddress'],
-          message: 'entryGatingAddress should not be set when entryGatingType is 4',
+          message: 'entryGatingAddress should not be set when entryGatingType is SegmentNfd',
         })
       } else if (entryGatingAssets.length > 1 || entryGatingAssets[0].value !== '') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingAssets'],
-          message: 'entryGatingAssets should not be set when entryGatingType is 4',
+          message: 'entryGatingAssets should not be set when entryGatingType is SegmentNfd',
         })
       } else if (entryGatingNfdCreator !== '') {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['entryGatingNfdCreator'],
-          message: 'entryGatingNfdCreator should not be set when entryGatingType is 4',
+          message: 'entryGatingNfdCreator should not be set when entryGatingType is SegmentNfd',
         })
       }
       break


### PR DESCRIPTION
### Fetch gating assets

Previously, the `AddValidatorForm` fieldset for entry gating had a simple UI for gating by asset ID. The user would enter 1-4 asset IDs and as long as they were positive integers they would pass validation and be sent to the registry contract on submission.

This updates the asset ID fields to use the `AssetLookup` component created for setting a reward token. It performs a debounced lookup of the input value and displays the asset's unit name if found (failing validation if not).

### Gating asset minimum balance

We've also decided on some additional constraints for `gatingAssetMinBalance`: it can only be set if there is a single gating asset. The form expects a whole unit amount that will be converted to base units on submission. Only one asset's `decimals` param can be used for the conversion.

If there are multiple gating assets, or if the gating type is creator address/NFD, the field is hidden and the `gatingAssetMinBalance` defaults to 1 base unit. Any amount of any qualified asset permits entry.

### Other changes

- Gating assets are now fetched and stored in the `Validator` objects as `validator.gatingAssets`
- Any gating assets in the add/edit form can be removed
- Gating asset minimum balance validation only happens when field is visible (value is strictly controlled when it isn't)
- Misc CSS/UI improvements