### PR TITLE
feat(ui): ValidatorTable global search and sunset filter

### DIFF
--- a/ui/src/components/DebouncedInput.tsx
+++ b/ui/src/components/DebouncedInput.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react'
+import { Input } from '@/components/ui/input'
+
+export interface DebouncedInputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> {
+  value: string | number
+  onChange: (value: string | number) => void
+  debounce?: number
+}
+
+export function DebouncedInput({
+  value: initialValue,
+  onChange,
+  debounce = 500,
+  ...props
+}: DebouncedInputProps) {
+  const [value, setValue] = React.useState(initialValue)
+
+  React.useEffect(() => {
+    setValue(initialValue)
+  }, [initialValue])
+
+  React.useEffect(() => {
+    const timeout = setTimeout(() => {
+      onChange(value)
+    }, debounce)
+
+    return () => clearTimeout(timeout)
+  }, [value])
+
+  return <Input {...props} value={value} onChange={(e) => setValue(e.target.value)} />
+}

--- a/ui/src/components/DebouncedSearch.tsx
+++ b/ui/src/components/DebouncedSearch.tsx
@@ -1,0 +1,56 @@
+import { X } from 'lucide-react'
+import * as React from 'react'
+import { DebouncedInput, DebouncedInputProps } from '@/components/DebouncedInput'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/utils/ui'
+
+export interface DebouncedSearchProps extends Omit<DebouncedInputProps, 'onChange'> {
+  onSearch: (value: string | number) => void
+}
+
+export function DebouncedSearch({
+  value: initialValue,
+  onSearch,
+  debounce,
+  className = '',
+  ...props
+}: DebouncedSearchProps) {
+  const [value, setValue] = React.useState(initialValue)
+
+  React.useEffect(() => {
+    onSearch(value)
+  }, [value])
+
+  const handleClear = () => {
+    setValue('')
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Escape') {
+      handleClear()
+    }
+  }
+
+  return (
+    <div className="relative">
+      <DebouncedInput
+        value={value}
+        onChange={setValue}
+        debounce={debounce}
+        onKeyDown={handleKeyDown}
+        {...props}
+        className={cn(className, { 'pr-10': value !== '' })}
+      />
+      {value !== '' && (
+        <Button
+          variant="ghost"
+          size="icon"
+          className="group absolute right-2 top-1/2 transform -translate-y-1/2 h-6 w-6"
+          onClick={handleClear}
+        >
+          <X className="h-4 w-4 opacity-60 transition-opacity group-hover:opacity-100" />
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/ui/src/components/StakingTable.tsx
+++ b/ui/src/components/StakingTable.tsx
@@ -53,6 +53,7 @@ import { dayjs } from '@/utils/dayjs'
 import { simulateEpoch } from '@/utils/development'
 import { ellipseAddressJsx } from '@/utils/ellipseAddress'
 import { formatAssetAmount } from '@/utils/format'
+import { globalFilterFn } from '@/utils/table'
 import { cn } from '@/utils/ui'
 
 interface StakingTableProps {
@@ -297,6 +298,9 @@ export function StakingTable({
   const table = useReactTable({
     data: stakesByValidator,
     columns,
+    filterFns: {
+      global: globalFilterFn,
+    },
     getCoreRowModel: getCoreRowModel(),
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),

--- a/ui/src/components/StakingTable.tsx
+++ b/ui/src/components/StakingTable.tsx
@@ -72,7 +72,6 @@ export function StakingTable({
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>([])
   const [columnVisibility, setColumnVisibility] = React.useState<VisibilityState>({})
-  const [rowSelection, setRowSelection] = React.useState({})
 
   const [addStakeValidator, setAddStakeValidator] = React.useState<Validator | null>(null)
   const [unstakeValidator, setUnstakeValidator] = React.useState<Validator | null>(null)
@@ -307,12 +306,10 @@ export function StakingTable({
     onColumnFiltersChange: setColumnFilters,
     getFilteredRowModel: getFilteredRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
-    onRowSelectionChange: setRowSelection,
     state: {
       sorting,
       columnFilters,
       columnVisibility,
-      rowSelection,
     },
   })
 

--- a/ui/src/interfaces/table.d.ts
+++ b/ui/src/interfaces/table.d.ts
@@ -1,0 +1,7 @@
+import { FilterFn } from '@tanstack/react-table'
+
+declare module '@tanstack/react-table' {
+  interface FilterFns {
+    global: FilterFn<unknown>
+  }
+}

--- a/ui/src/utils/table.ts
+++ b/ui/src/utils/table.ts
@@ -1,0 +1,50 @@
+import { FilterFn } from '@tanstack/react-table'
+import { Validator } from '@/interfaces/validator'
+import { isSunsetted } from '@/utils/contracts'
+
+export const globalFilterFn: FilterFn<Validator> = (row, columnId, filterValue) => {
+  if (filterValue === '') return true
+
+  const validator = row.original
+  const search = filterValue.toLowerCase()
+
+  const nfd = validator.nfd
+  const name = nfd?.name?.toLowerCase() ?? ''
+  const owner = validator.config.owner.toLowerCase()
+
+  if (name.includes(search)) return true
+  if (owner.includes(search)) return true
+
+  const rewardToken = validator.rewardToken
+  if (rewardToken) {
+    const tokenId = rewardToken.index.toString()
+    const { name, 'unit-name': unitName } = rewardToken.params
+    const tokenName = name?.toLowerCase() ?? ''
+    const tokenUnitName = unitName?.toLowerCase() ?? ''
+
+    if (tokenId === search) return true
+    if (tokenName.includes(search)) return true
+    if (tokenUnitName.includes(search)) return true
+  }
+
+  const gatingAssets = validator.gatingAssets
+  if (gatingAssets) {
+    const assetIds = gatingAssets.map((asset) => asset.index.toString())
+    const assetNames = gatingAssets.map((asset) => asset.params.name?.toLowerCase() ?? '')
+    const assetUnitnames = gatingAssets.map(
+      (asset) => asset.params['unit-name']?.toLowerCase() ?? '',
+    )
+
+    if (assetIds.some((id) => id === search)) return true
+    if (assetNames.some((name) => name.includes(search))) return true
+    if (assetUnitnames.some((unitName) => unitName.includes(search))) return true
+  }
+
+  return false
+}
+
+export const sunsetFilter: FilterFn<Validator> = (row, columnId, showSunsetted) => {
+  const validator = row.original
+  const isSunset = isSunsetted(validator)
+  return showSunsetted ? true : !isSunset
+}


### PR DESCRIPTION
Previously the validator filter only searched owner addresses or NFD names. Now it also searches reward token and gating assets by their ID, name, and unit name.

This also adds a filter to show/hide sunsetted validators, which defaults to hide.

Both of these filters are persisted in local storage, so between page refreshes and route navigations they will remain when you revisit the dashboard.