### PR TITLE
fix: clean up some typos and spacing in json files

### DIFF
--- a/contracts/contracts/artifacts/StakingPool.arc32.json
+++ b/contracts/contracts/artifacts/StakingPool.arc32.json
@@ -214,7 +214,7 @@
       },
       {
         "name": "initStorage",
-        "desc": "Called after we're created and then funded, so we can create our large stakers ledger storageCaller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage costIf this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.",
+        "desc": "Called after we're created and then funded, so we can create our large stakers ledger storage.  Caller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage cost. If this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.",
         "args": [
           {
             "name": "mbrPayment",
@@ -253,7 +253,7 @@
           {
             "name": "staker",
             "type": "address",
-            "desc": "account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This isso a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longermeet the gating requirements (determined by the node daemon)."
+            "desc": "account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This is so a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longer meet the gating requirements (determined by the node daemon)."
           },
           {
             "name": "amountToUnstake",
@@ -285,12 +285,12 @@
         ],
         "returns": {
           "type": "(address,uint64,uint64,uint64,uint64)",
-          "desc": "{StakedInfo}- The staked information for the given staker."
+          "desc": "{StakedInfo} - The staked information for the given staker."
         }
       },
       {
         "name": "payTokenReward",
-        "desc": "[Internal protocol method] Remove a specified amount of 'community token' rewards for a staker.This can ONLY be called by our validator and only if we're pool 1 - with the token.Note: this can also be called by validator as part of OWNER wanting to send the reward tokenssomewhere else (ie if they're sunsetting their validator and need the reward tokens back).It's up to the validator to ensure that the balance in rewardTokenHeldBack is honored.",
+        "desc": "[Internal protocol method] Remove a specified amount of 'community token' rewards for a staker. This can ONLY be called by our validator and only if we're pool 1 - with the token. Note: this can also be called by validator as part of OWNER wanting to send the reward tokenssomewhere else (ie if they're sunsetting their validator and need the reward tokens back).It's up to the validator to ensure that the balance in rewardTokenHeldBack is honored.",
         "args": [
           {
             "name": "staker",
@@ -314,7 +314,7 @@
       },
       {
         "name": "updateAlgodVer",
-        "desc": "Update the (honor system) algod version for the node associated to this pool.  The node management daemonshould compare its current nodes version to the version stored in global state, updating when different.The reti node daemon composes its own version string using format:{major}.{minor}.{build}{branch}[{commit hash}],ie: 3.22.0 rel/stable [6b508975][ ONLY OWNER OR MANAGER CAN CALL ]",
+        "desc": "Update the (honor system) algod version for the node associated to this pool.  The node management daemonshould compare its current nodes version to the version stored in global state, updating when different.The reti node daemon composes its own version string using format:{major}.{minor}.{build}{branch}[{commit hash}], ie: 3.22.0 rel/stable [6b508975][ ONLY OWNER OR MANAGER CAN CALL ]",
         "args": [
           {
             "name": "algodVer",
@@ -328,7 +328,7 @@
       },
       {
         "name": "epochBalanceUpdate",
-        "desc": "Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.The validator is paid their percentage each epoch payout.Note: ANYONE can call this.",
+        "desc": "Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.  The validator is paid their percentage each epoch payout.Note: ANYONE can call this.",
         "args": [],
         "returns": {
           "type": "void"
@@ -404,7 +404,7 @@
       },
       {
         "name": "proxiedSetTokenPayoutRatio",
-        "desc": "proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts",
+        "desc": "proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1. We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts",
         "args": [
           {
             "name": "poolKey",

--- a/contracts/contracts/artifacts/StakingPool.arc4.json
+++ b/contracts/contracts/artifacts/StakingPool.arc4.json
@@ -48,7 +48,7 @@
     },
     {
       "name": "initStorage",
-      "desc": "Called after we're created and then funded, so we can create our large stakers ledger storageCaller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage costIf this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.",
+      "desc": "Called after we're created and then funded, so we can create our large stakers ledger storage.  Caller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage cost. If this is pool 1 AND the validator has specified a reward token, opt-in to that token so that the validator can seed the pool with future rewards of that token.",
       "args": [
         {
           "name": "mbrPayment",
@@ -62,7 +62,7 @@
     },
     {
       "name": "addStake",
-      "desc": "Adds stake to the given account.Can ONLY be called by the validator contract that created usMust receive payment from the validator contract for amount being staked.",
+      "desc": "Adds stake to the given account. Can ONLY be called by the validator contract that created usMust receive payment from the validator contract for amount being staked.",
       "args": [
         {
           "name": "stakedAmountPayment",
@@ -87,7 +87,7 @@
         {
           "name": "staker",
           "type": "address",
-          "desc": "account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This isso a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longermeet the gating requirements (determined by the node daemon)."
+          "desc": "account to remove.  normally same as sender, but the validator owner or manager can also call this to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This is so a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longer meet the gating requirements (determined by the node daemon)."
         },
         {
           "name": "amountToUnstake",
@@ -119,12 +119,12 @@
       ],
       "returns": {
         "type": "(address,uint64,uint64,uint64,uint64)",
-        "desc": "{StakedInfo}- The staked information for the given staker."
+        "desc": "{StakedInfo} - The staked information for the given staker."
       }
     },
     {
       "name": "payTokenReward",
-      "desc": "[Internal protocol method] Remove a specified amount of 'community token' rewards for a staker.This can ONLY be called by our validator and only if we're pool 1 - with the token.Note: this can also be called by validator as part of OWNER wanting to send the reward tokenssomewhere else (ie if they're sunsetting their validator and need the reward tokens back).It's up to the validator to ensure that the balance in rewardTokenHeldBack is honored.",
+      "desc": "[Internal protocol method] Remove a specified amount of 'community token' rewards for a staker. This can ONLY be called by our validator and only if we're pool 1 - with the token. Note: this can also be called by validator as part of OWNER wanting to send the reward tokens somewhere else (ie if they're sunsetting their validator and need the reward tokens back). It's up to the validator to ensure that the balance in rewardTokenHeldBack is honored.",
       "args": [
         {
           "name": "staker",
@@ -148,7 +148,7 @@
     },
     {
       "name": "updateAlgodVer",
-      "desc": "Update the (honor system) algod version for the node associated to this pool.  The node management daemonshould compare its current nodes version to the version stored in global state, updating when different.The reti node daemon composes its own version string using format:{major}.{minor}.{build}{branch}[{commit hash}],ie: 3.22.0 rel/stable [6b508975][ ONLY OWNER OR MANAGER CAN CALL ]",
+      "desc": "Update the (honor system) algod version for the node associated to this pool.  The node management daemonshould compare its current nodes version to the version stored in global state, updating when different.The reti node daemon composes its own version string using format:{major}.{minor}.{build}{branch}[{commit hash}], ie: 3.22.0 rel/stable [6b508975] [ ONLY OWNER OR MANAGER CAN CALL ]",
       "args": [
         {
           "name": "algodVer",
@@ -162,7 +162,7 @@
     },
     {
       "name": "epochBalanceUpdate",
-      "desc": "Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.The validator is paid their percentage each epoch payout.Note: ANYONE can call this.",
+      "desc": "Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance) stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will. The validator is paid their percentage each epoch payout. Note: ANYONE can call this.",
       "args": [],
       "returns": {
         "type": "void"
@@ -170,7 +170,7 @@
     },
     {
       "name": "goOnline",
-      "desc": "Registers a staking pool key online against a participation key.[ ONLY OWNER OR MANAGER CAN CALL ]",
+      "desc": "Registers a staking pool key online against a participation key. [ ONLY OWNER OR MANAGER CAN CALL ]",
       "args": [
         {
           "name": "feePayment",
@@ -214,7 +214,7 @@
     },
     {
       "name": "goOffline",
-      "desc": "Marks a staking pool key OFFLINE.[ ONLY OWNER OR MANAGER CAN CALL ]",
+      "desc": "Marks a staking pool key OFFLINE. [ ONLY OWNER OR MANAGER CAN CALL ]",
       "args": [],
       "returns": {
         "type": "void"
@@ -238,7 +238,7 @@
     },
     {
       "name": "proxiedSetTokenPayoutRatio",
-      "desc": "proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts",
+      "desc": "proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1.  We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts",
       "args": [
         {
           "name": "poolKey",

--- a/contracts/contracts/artifacts/ValidatorRegistry.arc32.json
+++ b/contracts/contracts/artifacts/ValidatorRegistry.arc32.json
@@ -352,7 +352,7 @@
           {
             "name": "validatorId",
             "type": "uint64",
-            "desc": "@return{PoolInfo[]}- array of poolsNot callable from other contracts because>1K return but can be called w/ simulate which bumps log returns"
+            "desc": "@return{PoolInfo[]} - array of poolsNot callable from other contracts because >1K return but can be called w/ simulate which bumps log returns"
           }
         ],
         "returns": {
@@ -435,7 +435,7 @@
           {
             "name": "validatorId",
             "type": "uint64",
-            "desc": "The id of the validator.@return{PoolTokenPayoutRatio}- The token payout ratio for the validator."
+            "desc": "The id of the validator. @return{PoolTokenPayoutRatio}- The token payout ratio for the validator."
           }
         ],
         "returns": {
@@ -695,7 +695,7 @@
           {
             "name": "saturatedBurnToFeeSink",
             "type": "uint64",
-            "desc": "if the pool was in saturated state, the amount sent back to the fee sink.seen as 'accounted for/pending spent')"
+            "desc": "if the pool was in saturated state, the amount sent back to the fee sink.  Seen as 'accounted for/pending spent')"
           }
         ],
         "returns": {
@@ -761,7 +761,7 @@
       },
       {
         "name": "movePoolToNode",
-        "desc": "Find the specified pool (in any node number) and move it to the specified node.The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]",
+        "desc": "Find the specified pool (in any node number) and move it to the specified node.  The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]",
         "args": [
           {
             "name": "validatorId",
@@ -783,7 +783,7 @@
       },
       {
         "name": "emptyTokenRewards",
-        "desc": "Sends the reward tokens held in pool 1 to specified receiver.This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim willNOT be sent as they must be held back for stakers to later claim.[ ONLY OWNER CAN CALL]",
+        "desc": "Sends the reward tokens held in pool 1 to specified receiver.  This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim will NOT be sent as they must be held back for stakers to later claim. [ ONLY OWNER CAN CALL]",
         "args": [
           {
             "name": "validatorId",

--- a/contracts/contracts/artifacts/ValidatorRegistry.arc4.json
+++ b/contracts/contracts/artifacts/ValidatorRegistry.arc4.json
@@ -126,7 +126,7 @@
         {
           "name": "validatorId",
           "type": "uint64",
-          "desc": "@return{PoolInfo[]}- array of poolsNot callable from other contracts because>1K return but can be called w/ simulate which bumps log returns"
+          "desc": "@return{PoolInfo[]} - array of pools not callable from other contracts because >1K return but can be called w/ simulate which bumps log returns"
         }
       ],
       "returns": {
@@ -163,7 +163,7 @@
     },
     {
       "name": "getCurMaxStakePerPool",
-      "desc": "Calculate the maximum stake per pool for a given validator.Normally this would be maxAlgoPerPool, but it should also never go above MaxAllowedStake / numPools soas pools are added the max allowed per pool can reduce.",
+      "desc": "Calculate the maximum stake per pool for a given validator. Normally this would be maxAlgoPerPool, but it should also never go above MaxAllowedStake / numPools soas pools are added the max allowed per pool can reduce.",
       "args": [
         {
           "name": "validatorId",
@@ -195,7 +195,7 @@
         {
           "name": "staker",
           "type": "address",
-          "desc": "The account to retrieve staked pools for.@return{ValidatorPoolKey[]}- The array of staked pools for the account."
+          "desc": "The account to retrieve staked pools for @return{ValidatorPoolKey[]} - The array of staked pools for the account."
         }
       ],
       "returns": {
@@ -204,12 +204,12 @@
     },
     {
       "name": "getTokenPayoutRatio",
-      "desc": "Retrieves the token payout ratio for a given validator - returning the pool ratios of whole so that tokenpayouts across pools can be based on a stable snaphost of stake.",
+      "desc": "Retrieves the token payout ratio for a given validator - returning the pool ratios of whole so that token payouts across pools can be based on a stable snaphost of stake.",
       "args": [
         {
           "name": "validatorId",
           "type": "uint64",
-          "desc": "The id of the validator.@return{PoolTokenPayoutRatio}- The token payout ratio for the validator."
+          "desc": "The id of the validator. @return{PoolTokenPayoutRatio}- The token payout ratio for the validator."
         }
       ],
       "returns": {
@@ -237,7 +237,7 @@
     },
     {
       "name": "addValidator",
-      "desc": "Adds a new validatorRequires at least 10 ALGO as the 'fee' for the transaction to help dissuade spammed validator adds.",
+      "desc": "Adds a new validator. Requires at least 10 ALGO as the 'fee' for the transaction to help dissuade spammed validator adds.",
       "args": [
         {
           "name": "mbrPayment",
@@ -262,7 +262,7 @@
     },
     {
       "name": "changeValidatorManager",
-      "desc": "Changes the Validator manager for a specific Validator id.[ ONLY OWNER CAN CHANGE ]",
+      "desc": "Changes the Validator manager for a specific Validator id. [ ONLY OWNER CAN CHANGE ]",
       "args": [
         {
           "name": "validatorId",
@@ -281,7 +281,7 @@
     },
     {
       "name": "changeValidatorSunsetInfo",
-      "desc": "Updates the sunset information for a given validator.[ ONLY OWNER CAN CHANGE ]",
+      "desc": "Updates the sunset information for a given validator. [ ONLY OWNER CAN CHANGE ]",
       "args": [
         {
           "name": "validatorId",
@@ -305,7 +305,7 @@
     },
     {
       "name": "changeValidatorNFD",
-      "desc": "Changes the NFD for a validator in the validatorList contract.[ ONLY OWNER CAN CHANGE ]",
+      "desc": "Changes the NFD for a validator in the validatorList contract. [ ONLY OWNER CAN CHANGE ]",
       "args": [
         {
           "name": "validatorId",
@@ -329,7 +329,7 @@
     },
     {
       "name": "changeValidatorCommissionAddress",
-      "desc": "Change the commission address that validator rewards are sent to.[ ONLY OWNER CAN CHANGE ]",
+      "desc": "Change the commission address that validator rewards are sent to. [ ONLY OWNER CAN CHANGE ]",
       "args": [
         {
           "name": "validatorId",
@@ -346,7 +346,7 @@
     },
     {
       "name": "changeValidatorRewardInfo",
-      "desc": "Allow the additional rewards (gating entry, additional token rewards) information be changed at will.[ ONLY OWNER CAN CHANGE ]",
+      "desc": "Allow the additional rewards (gating entry, additional token rewards) information be changed at will. [ ONLY OWNER CAN CHANGE ]",
       "args": [
         {
           "name": "validatorId",
@@ -379,7 +379,7 @@
     },
     {
       "name": "addPool",
-      "desc": "Adds a new pool to a validator's pool set, returning the 'key' to reference the pool in the future for staking, etc.The caller must pay the cost of the validators MBR increase as well as the MBR that will be needed for the pool itself.[ ONLY OWNER OR MANAGER CAN call ]",
+      "desc": "Adds a new pool to a validator's pool set, returning the 'key' to reference the pool in the future for staking, etc. The caller must pay the cost of the validators MBR increase as well as the MBR that will be needed for the pool itself. [ ONLY OWNER OR MANAGER CAN call ]",
       "args": [
         {
           "name": "mbrPayment",
@@ -399,7 +399,7 @@
       ],
       "returns": {
         "type": "(uint64,uint64,uint64)",
-        "desc": "{ValidatorPoolKey}pool key to created pool"
+        "desc": "{ValidatorPoolKey} pool key to created pool"
       }
     },
     {
@@ -419,7 +419,7 @@
         {
           "name": "valueToVerify",
           "type": "uint64",
-          "desc": "only if validator has gating to enter - this is asset id or nfd id that corresponds to gating.Txn sender is factored in as well if that is part of gating.*"
+          "desc": "only if validator has gating to enter - this is asset id or nfd id that corresponds to gating. Txn sender is factored in as well if that is part of gating.*"
         }
       ],
       "returns": {
@@ -429,7 +429,7 @@
     },
     {
       "name": "setTokenPayoutRatio",
-      "desc": "setTokenPayoutRatio is called by Staking Pool # 1 (ONLY) to ask the validator (us) to calculate the ratiosof stake in the pools for subsequent token payouts (ie: 2 pools, '100' algo total staked, 60 in pool 1, and 40in pool 2)  This is done so we have a stable snapshot of stake - taken once per epoch - only triggered bypool 1 doing payout.  pools other than 1 doing payout call pool 1 to ask it do it first.It would be 60/40% in the poolPctOfWhole values.  The token reward payouts then use these values instead oftheir 'current' stake which changes as part of the payouts themselves (and people could be changing stakeduring the epoch updates across pools)Multiple pools will call us via pool 1 (pool2->pool1->validator, etc.) so don't assert on pool1 calling multipletimes in same epoch.  Just return.",
+      "desc": "setTokenPayoutRatio is called by Staking Pool # 1 (ONLY) to ask the validator (us) to calculate the ratios of stake in the pools for subsequent token payouts (ie: 2 pools, '100' algo total staked, 60 in pool 1, and 40 in pool 2). This is done so we have a stable snapshot of stake - taken once per epoch - only triggered by pool 1 doing payout.  Pools other than 1 doing payout call pool 1 to ask it do it first.  It would be 60/40% in the poolPctOfWhole values.  The token reward payouts then use these values instead of their 'current' stake which changes as part of the payouts themselves (and people could be changing stake during the epoch updates across pools). Multiple pools will call us via pool 1 (pool2->pool1->validator, etc.) so don't assert on pool 1 calling multiple times in same epoch.  Just return.",
       "args": [
         {
           "name": "validatorId",
@@ -444,7 +444,7 @@
     },
     {
       "name": "stakeUpdatedViaRewards",
-      "desc": "stakeUpdatedViaRewards is called by Staking pools to inform the validator (us) that a particular amount of totalstake has been added to the specified pool.  This is used to update the stats we have in our PoolInfo storage.The calling App id is validated against our pool list as well.",
+      "desc": "stakeUpdatedViaRewards is called by Staking pools to inform the validator (us) that a particular amount of totalstake has been added to the specified pool.  This is used to update the stats we have in our PoolInfo storage. The calling App id is validated against our pool list as well.",
       "args": [
         {
           "name": "poolKey",
@@ -469,7 +469,7 @@
         {
           "name": "saturatedBurnToFeeSink",
           "type": "uint64",
-          "desc": "if the pool was in saturated state, the amount sent back to the fee sink.seen as 'accounted for/pending spent')"
+          "desc": "if the pool is in saturated state, this is the amount sent back to the fee sink. Seen as 'accounted for/pending spent')"
         }
       ],
       "returns": {
@@ -478,7 +478,7 @@
     },
     {
       "name": "stakeRemoved",
-      "desc": "stakeRemoved is called by Staking pools to inform the validator (us) that a particular amount of total stake has been removedfrom the specified pool.  This is used to update the stats we have in our PoolInfo storage.If any amount of rewardRemoved is specified, then that amount of reward is sent to the useThe calling App id is validated against our pool list as well.",
+      "desc": "stakeRemoved is called by Staking pools to inform the validator (us) that a particular amount of total stake has been removed from the specified pool.  This is used to update the stats we have in our PoolInfo storage. If any amount of rewardRemoved is specified, then that amount of reward is sent to the user. The calling App id is validated against our pool list as well.",
       "args": [
         {
           "name": "poolKey",
@@ -535,7 +535,7 @@
     },
     {
       "name": "movePoolToNode",
-      "desc": "Find the specified pool (in any node number) and move it to the specified node.The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]",
+      "desc": "Find the specified pool (in any node number) and move it to the specified node.  The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]",
       "args": [
         {
           "name": "validatorId",
@@ -557,7 +557,7 @@
     },
     {
       "name": "emptyTokenRewards",
-      "desc": "Sends the reward tokens held in pool 1 to specified receiver.This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim willNOT be sent as they must be held back for stakers to later claim.[ ONLY OWNER CAN CALL]",
+      "desc": "Sends the reward tokens held in pool 1 to specified receiver. This is intended to be used by the owner when they want to get reward tokens 'back' which they sent to the first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim will NOT be sent as they must be held back for stakers to later claim. [ ONLY OWNER CAN CALL]",
       "args": [
         {
           "name": "validatorId",

--- a/contracts/contracts/clients/StakingPoolClient.ts
+++ b/contracts/contracts/clients/StakingPoolClient.ts
@@ -244,7 +244,7 @@ export const APP_SPEC: AppSpec = {
       },
       {
         "name": "initStorage",
-        "desc": "Called after we're created and then funded, so we can create our large stakers ledger storageCaller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage costIf this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.",
+        "desc": "Called after we're created and then funded, so we can create our large stakers ledger storage.  Caller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage cost. If this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.",
         "args": [
           {
             "name": "mbrPayment",
@@ -283,7 +283,7 @@ export const APP_SPEC: AppSpec = {
           {
             "name": "staker",
             "type": "address",
-            "desc": "account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This isso a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longermeet the gating requirements (determined by the node daemon)."
+            "desc": "account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This is so a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longer meet the gating requirements (determined by the node daemon)."
           },
           {
             "name": "amountToUnstake",
@@ -315,7 +315,7 @@ export const APP_SPEC: AppSpec = {
         ],
         "returns": {
           "type": "(address,uint64,uint64,uint64,uint64)",
-          "desc": "{StakedInfo}- The staked information for the given staker."
+          "desc": "{StakedInfo} - The staked information for the given staker."
         }
       },
       {
@@ -358,7 +358,7 @@ export const APP_SPEC: AppSpec = {
       },
       {
         "name": "epochBalanceUpdate",
-        "desc": "Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.The validator is paid their percentage each epoch payout.Note: ANYONE can call this.",
+        "desc": "Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.  The validator is paid their percentage each epoch payout.Note: ANYONE can call this.",
         "args": [],
         "returns": {
           "type": "void"
@@ -434,7 +434,7 @@ export const APP_SPEC: AppSpec = {
       },
       {
         "name": "proxiedSetTokenPayoutRatio",
-        "desc": "proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts",
+        "desc": "proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1.  We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts",
         "args": [
           {
             "name": "poolKey",
@@ -584,7 +584,7 @@ export type StakingPool = {
     & Record<'removeStake(address,uint64)void' | 'removeStake', {
       argsObj: {
         /**
-         * account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This isso a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longermeet the gating requirements (determined by the node daemon).
+         * account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This is so a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longer meet the gating requirements (determined by the node daemon).
          */
         staker: string
         /**
@@ -610,7 +610,7 @@ export type StakingPool = {
       }
       argsTuple: [staker: string]
       /**
-       * {StakedInfo}- The staked information for the given staker.
+       * {StakedInfo} - The staked information for the given staker.
        */
       returns: [string, bigint, bigint, bigint, bigint]
     }>
@@ -853,7 +853,7 @@ export abstract class StakingPoolCallFactory {
   /**
    * Constructs a no op call for the initStorage(pay)void ABI method
    *
-   * Called after we're created and then funded, so we can create our large stakers ledger storageCaller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage costIf this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.
+   * Called after we're created and then funded, so we can create our large stakers ledger storage.  Caller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage cost. If this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.
    *
    * @param args Any args for the contract call
    * @param params Any additional parameters for the call
@@ -965,7 +965,7 @@ export abstract class StakingPoolCallFactory {
   /**
    * Constructs a no op call for the epochBalanceUpdate()void ABI method
    *
-   * Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.The validator is paid their percentage each epoch payout.Note: ANYONE can call this.
+   * Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.  The validator is paid their percentage each epoch payout.Note: ANYONE can call this.
    *
    * @param args Any args for the contract call
    * @param params Any additional parameters for the call
@@ -1027,7 +1027,7 @@ export abstract class StakingPoolCallFactory {
   /**
    * Constructs a no op call for the proxiedSetTokenPayoutRatio((uint64,uint64,uint64))(uint64[24],uint64) ABI method
    *
-   * proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts
+   * proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1.  We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts
    *
    * @param args Any args for the contract call
    * @param params Any additional parameters for the call
@@ -1176,7 +1176,7 @@ export class StakingPoolClient {
   /**
    * Calls the initStorage(pay)void ABI method.
    *
-   * Called after we're created and then funded, so we can create our large stakers ledger storageCaller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage costIf this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.
+   * Called after we're created and then funded, so we can create our large stakers ledger storage.  Caller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage cost. If this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -1232,7 +1232,7 @@ export class StakingPoolClient {
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
-   * @returns The result of the call: {StakedInfo}- The staked information for the given staker.
+   * @returns The result of the call: {StakedInfo} - The staked information for the given staker.
    */
   public getStakerInfo(args: MethodArgs<'getStakerInfo(address)(address,uint64,uint64,uint64,uint64)'>, params: AppClientCallCoreParams & CoreAppCallArgs = {}) {
     return this.call(StakingPoolCallFactory.getStakerInfo(args, params))
@@ -1267,7 +1267,7 @@ export class StakingPoolClient {
   /**
    * Calls the epochBalanceUpdate()void ABI method.
    *
-   * Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.The validator is paid their percentage each epoch payout.Note: ANYONE can call this.
+   * Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.  The validator is paid their percentage each epoch payout.Note: ANYONE can call this.
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -1317,7 +1317,7 @@ export class StakingPoolClient {
   /**
    * Calls the proxiedSetTokenPayoutRatio((uint64,uint64,uint64))(uint64[24],uint64) ABI method.
    *
-   * proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts
+   * proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1.  We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -1550,7 +1550,7 @@ export type StakingPoolComposer<TReturns extends [...any[]] = []> = {
   /**
    * Calls the initStorage(pay)void ABI method.
    *
-   * Called after we're created and then funded, so we can create our large stakers ledger storageCaller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage costIf this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.
+   * Called after we're created and then funded, so we can create our large stakers ledger storage.  Caller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage cost. If this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -1627,7 +1627,7 @@ export type StakingPoolComposer<TReturns extends [...any[]] = []> = {
   /**
    * Calls the epochBalanceUpdate()void ABI method.
    *
-   * Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.The validator is paid their percentage each epoch payout.Note: ANYONE can call this.
+   * Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.  The validator is paid their percentage each epoch payout.Note: ANYONE can call this.
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -1669,7 +1669,7 @@ export type StakingPoolComposer<TReturns extends [...any[]] = []> = {
   /**
    * Calls the proxiedSetTokenPayoutRatio((uint64,uint64,uint64))(uint64[24],uint64) ABI method.
    *
-   * proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts
+   * proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1.  We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call

--- a/contracts/contracts/clients/ValidatorRegistryClient.ts
+++ b/contracts/contracts/clients/ValidatorRegistryClient.ts
@@ -382,7 +382,7 @@ export const APP_SPEC: AppSpec = {
           {
             "name": "validatorId",
             "type": "uint64",
-            "desc": "@return{PoolInfo[]}- array of poolsNot callable from other contracts because>1K return but can be called w/ simulate which bumps log returns"
+            "desc": "@return{PoolInfo[]} - array of poolsNot callable from other contracts because >1K return but can be called w/ simulate which bumps log returns"
           }
         ],
         "returns": {
@@ -465,7 +465,7 @@ export const APP_SPEC: AppSpec = {
           {
             "name": "validatorId",
             "type": "uint64",
-            "desc": "The id of the validator.@return{PoolTokenPayoutRatio}- The token payout ratio for the validator."
+            "desc": "The id of the validator. @return{PoolTokenPayoutRatio}- The token payout ratio for the validator."
           }
         ],
         "returns": {
@@ -725,7 +725,7 @@ export const APP_SPEC: AppSpec = {
           {
             "name": "saturatedBurnToFeeSink",
             "type": "uint64",
-            "desc": "if the pool was in saturated state, the amount sent back to the fee sink.seen as 'accounted for/pending spent')"
+            "desc": "if the pool was in saturated state, the amount sent back to the fee sink.  Seen as 'accounted for/pending spent')"
           }
         ],
         "returns": {
@@ -791,7 +791,7 @@ export const APP_SPEC: AppSpec = {
       },
       {
         "name": "movePoolToNode",
-        "desc": "Find the specified pool (in any node number) and move it to the specified node.The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]",
+        "desc": "Find the specified pool (in any node number) and move it to the specified node.  The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]",
         "args": [
           {
             "name": "validatorId",
@@ -813,7 +813,7 @@ export const APP_SPEC: AppSpec = {
       },
       {
         "name": "emptyTokenRewards",
-        "desc": "Sends the reward tokens held in pool 1 to specified receiver.This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim willNOT be sent as they must be held back for stakers to later claim.[ ONLY OWNER CAN CALL]",
+        "desc": "Sends the reward tokens held in pool 1 to specified receiver.  This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim will NOT be sent as they must be held back for stakers to later claim. [ ONLY OWNER CAN CALL]",
         "args": [
           {
             "name": "validatorId",
@@ -986,7 +986,7 @@ export type ValidatorRegistry = {
     & Record<'getPools(uint64)(uint64,uint16,uint64)[]' | 'getPools', {
       argsObj: {
         /**
-         * @return{PoolInfo[]}- array of poolsNot callable from other contracts because>1K return but can be called w/ simulate which bumps log returns
+         * @return{PoolInfo[]} - array of poolsNot callable from other contracts because >1K return but can be called w/ simulate which bumps log returns
          */
         validatorId: bigint | number
       }
@@ -1038,7 +1038,7 @@ export type ValidatorRegistry = {
     & Record<'getTokenPayoutRatio(uint64)(uint64[24],uint64)' | 'getTokenPayoutRatio', {
       argsObj: {
         /**
-         * The id of the validator.@return{PoolTokenPayoutRatio}- The token payout ratio for the validator.
+         * The id of the validator. @return{PoolTokenPayoutRatio}- The token payout ratio for the validator.
          */
         validatorId: bigint | number
       }
@@ -1223,7 +1223,7 @@ export type ValidatorRegistry = {
          */
         validatorCommission: bigint | number
         /**
-         * if the pool was in saturated state, the amount sent back to the fee sink.seen as 'accounted for/pending spent')
+         * if the pool was in saturated state, the amount sent back to the fee sink.  Seen as 'accounted for/pending spent')
          */
         saturatedBurnToFeeSink: bigint | number
       }
@@ -1897,7 +1897,7 @@ export abstract class ValidatorRegistryCallFactory {
   /**
    * Constructs a no op call for the movePoolToNode(uint64,uint64,uint64)void ABI method
    *
-   * Find the specified pool (in any node number) and move it to the specified node.The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]
+   * Find the specified pool (in any node number) and move it to the specified node.  The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]
    *
    * @param args Any args for the contract call
    * @param params Any additional parameters for the call
@@ -1913,7 +1913,7 @@ export abstract class ValidatorRegistryCallFactory {
   /**
    * Constructs a no op call for the emptyTokenRewards(uint64,address)uint64 ABI method
    *
-   * Sends the reward tokens held in pool 1 to specified receiver.This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim willNOT be sent as they must be held back for stakers to later claim.[ ONLY OWNER CAN CALL]
+   * Sends the reward tokens held in pool 1 to specified receiver.  This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim will NOT be sent as they must be held back for stakers to later claim. [ ONLY OWNER CAN CALL]
    *
    * @param args Any args for the contract call
    * @param params Any additional parameters for the call
@@ -2432,7 +2432,7 @@ export class ValidatorRegistryClient {
   /**
    * Calls the movePoolToNode(uint64,uint64,uint64)void ABI method.
    *
-   * Find the specified pool (in any node number) and move it to the specified node.The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]
+   * Find the specified pool (in any node number) and move it to the specified node.  The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -2445,7 +2445,7 @@ export class ValidatorRegistryClient {
   /**
    * Calls the emptyTokenRewards(uint64,address)uint64 ABI method.
    *
-   * Sends the reward tokens held in pool 1 to specified receiver.This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim willNOT be sent as they must be held back for stakers to later claim.[ ONLY OWNER CAN CALL]
+   * Sends the reward tokens held in pool 1 to specified receiver.  This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim will NOT be sent as they must be held back for stakers to later claim. [ ONLY OWNER CAN CALL]
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -3058,7 +3058,7 @@ export type ValidatorRegistryComposer<TReturns extends [...any[]] = []> = {
   /**
    * Calls the movePoolToNode(uint64,uint64,uint64)void ABI method.
    *
-   * Find the specified pool (in any node number) and move it to the specified node.The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]
+   * Find the specified pool (in any node number) and move it to the specified node.  The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -3069,7 +3069,7 @@ export type ValidatorRegistryComposer<TReturns extends [...any[]] = []> = {
   /**
    * Calls the emptyTokenRewards(uint64,address)uint64 ABI method.
    *
-   * Sends the reward tokens held in pool 1 to specified receiver.This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim willNOT be sent as they must be held back for stakers to later claim.[ ONLY OWNER CAN CALL]
+   * Sends the reward tokens held in pool 1 to specified receiver.  This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim will NOT be sent as they must be held back for stakers to later claim. [ ONLY OWNER CAN CALL]
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call

--- a/nodemgr/internal/lib/reti/artifacts/contracts/StakingPool.arc32.json
+++ b/nodemgr/internal/lib/reti/artifacts/contracts/StakingPool.arc32.json
@@ -214,7 +214,7 @@
       },
       {
         "name": "initStorage",
-        "desc": "Called after we're created and then funded, so we can create our large stakers ledger storageCaller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage costIf this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.",
+        "desc": "Called after we're created and then funded, so we can create our large stakers ledger storage.  Caller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage cost. If this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.",
         "args": [
           {
             "name": "mbrPayment",
@@ -253,7 +253,7 @@
           {
             "name": "staker",
             "type": "address",
-            "desc": "account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This isso a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longermeet the gating requirements (determined by the node daemon)."
+            "desc": "account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This is so a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longer meet the gating requirements (determined by the node daemon)."
           },
           {
             "name": "amountToUnstake",
@@ -285,7 +285,7 @@
         ],
         "returns": {
           "type": "(address,uint64,uint64,uint64,uint64)",
-          "desc": "{StakedInfo}- The staked information for the given staker."
+          "desc": "{StakedInfo} - The staked information for the given staker."
         }
       },
       {
@@ -314,7 +314,7 @@
       },
       {
         "name": "updateAlgodVer",
-        "desc": "Update the (honor system) algod version for the node associated to this pool.  The node management daemonshould compare its current nodes version to the version stored in global state, updating when different.The reti node daemon composes its own version string using format:{major}.{minor}.{build}{branch}[{commit hash}],ie: 3.22.0 rel/stable [6b508975][ ONLY OWNER OR MANAGER CAN CALL ]",
+        "desc": "Update the (honor system) algod version for the node associated to this pool.  The node management daemonshould compare its current nodes version to the version stored in global state, updating when different. The reti node daemon composes its own version string using format:{major}.{minor}.{build}{branch}[{commit hash}], ie: 3.22.0 rel/stable [6b508975][ ONLY OWNER OR MANAGER CAN CALL ]",
         "args": [
           {
             "name": "algodVer",
@@ -328,7 +328,7 @@
       },
       {
         "name": "epochBalanceUpdate",
-        "desc": "Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.The validator is paid their percentage each epoch payout.Note: ANYONE can call this.",
+        "desc": "Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balance compounds over time and staker can remove that amount at will. The validator is paid their percentage each epoch payout. Note: ANYONE can call this.",
         "args": [],
         "returns": {
           "type": "void"
@@ -404,7 +404,7 @@
       },
       {
         "name": "proxiedSetTokenPayoutRatio",
-        "desc": "proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts",
+        "desc": "proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1. We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts",
         "args": [
           {
             "name": "poolKey",

--- a/nodemgr/internal/lib/reti/artifacts/contracts/ValidatorRegistry.arc32.json
+++ b/nodemgr/internal/lib/reti/artifacts/contracts/ValidatorRegistry.arc32.json
@@ -352,7 +352,7 @@
           {
             "name": "validatorId",
             "type": "uint64",
-            "desc": "@return{PoolInfo[]}- array of poolsNot callable from other contracts because>1K return but can be called w/ simulate which bumps log returns"
+            "desc": "@return{PoolInfo[]} - array of poolsNot callable from other contracts because >1K return but can be called w/ simulate which bumps log returns"
           }
         ],
         "returns": {
@@ -435,7 +435,7 @@
           {
             "name": "validatorId",
             "type": "uint64",
-            "desc": "The id of the validator.@return{PoolTokenPayoutRatio}- The token payout ratio for the validator."
+            "desc": "The id of the validator. @return{PoolTokenPayoutRatio}- The token payout ratio for the validator."
           }
         ],
         "returns": {
@@ -695,7 +695,7 @@
           {
             "name": "saturatedBurnToFeeSink",
             "type": "uint64",
-            "desc": "if the pool was in saturated state, the amount sent back to the fee sink.seen as 'accounted for/pending spent')"
+            "desc": "if the pool was in saturated state, the amount sent back to the fee sink.  Seen as 'accounted for/pending spent')"
           }
         ],
         "returns": {
@@ -761,7 +761,7 @@
       },
       {
         "name": "movePoolToNode",
-        "desc": "Find the specified pool (in any node number) and move it to the specified node.The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]",
+        "desc": "Find the specified pool (in any node number) and move it to the specified node.  The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]",
         "args": [
           {
             "name": "validatorId",
@@ -783,7 +783,7 @@
       },
       {
         "name": "emptyTokenRewards",
-        "desc": "Sends the reward tokens held in pool 1 to specified receiver.This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim willNOT be sent as they must be held back for stakers to later claim.[ ONLY OWNER CAN CALL]",
+        "desc": "Sends the reward tokens held in pool 1 to specified receiver.  This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim will NOT be sent as they must be held back for stakers to later claim. [ ONLY OWNER CAN CALL]",
         "args": [
           {
             "name": "validatorId",

--- a/ui/src/contracts/StakingPoolClient.ts
+++ b/ui/src/contracts/StakingPoolClient.ts
@@ -244,7 +244,7 @@ export const APP_SPEC: AppSpec = {
       },
       {
         "name": "initStorage",
-        "desc": "Called after we're created and then funded, so we can create our large stakers ledger storageCaller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage costIf this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.",
+        "desc": "Called after we're created and then funded, so we can create our large stakers ledger storage.  Caller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage cost. If this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.",
         "args": [
           {
             "name": "mbrPayment",
@@ -283,7 +283,7 @@ export const APP_SPEC: AppSpec = {
           {
             "name": "staker",
             "type": "address",
-            "desc": "account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This isso a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longermeet the gating requirements (determined by the node daemon)."
+            "desc": "account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This is so a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longer meet the gating requirements (determined by the node daemon)."
           },
           {
             "name": "amountToUnstake",
@@ -315,7 +315,7 @@ export const APP_SPEC: AppSpec = {
         ],
         "returns": {
           "type": "(address,uint64,uint64,uint64,uint64)",
-          "desc": "{StakedInfo}- The staked information for the given staker."
+          "desc": "{StakedInfo} - The staked information for the given staker."
         }
       },
       {
@@ -358,7 +358,7 @@ export const APP_SPEC: AppSpec = {
       },
       {
         "name": "epochBalanceUpdate",
-        "desc": "Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.The validator is paid their percentage each epoch payout.Note: ANYONE can call this.",
+        "desc": "Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.  The validator is paid their percentage each epoch payout.Note: ANYONE can call this.",
         "args": [],
         "returns": {
           "type": "void"
@@ -434,7 +434,7 @@ export const APP_SPEC: AppSpec = {
       },
       {
         "name": "proxiedSetTokenPayoutRatio",
-        "desc": "proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts",
+        "desc": "proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1.  We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts",
         "args": [
           {
             "name": "poolKey",
@@ -584,7 +584,7 @@ export type StakingPool = {
     & Record<'removeStake(address,uint64)void' | 'removeStake', {
       argsObj: {
         /**
-         * account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This isso a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longermeet the gating requirements (determined by the node daemon).
+         * account to remove.  normally same as sender, but the validator owner or manager can also callthis to remove the specified staker explicitly. The removed stake MUST only go to the staker of course.  This is so a validator can shut down a poool and refund the stakers.  It can also be used to kick out stakers who no longer meet the gating requirements (determined by the node daemon).
          */
         staker: string
         /**
@@ -610,7 +610,7 @@ export type StakingPool = {
       }
       argsTuple: [staker: string]
       /**
-       * {StakedInfo}- The staked information for the given staker.
+       * {StakedInfo} - The staked information for the given staker.
        */
       returns: [string, bigint, bigint, bigint, bigint]
     }>
@@ -853,7 +853,7 @@ export abstract class StakingPoolCallFactory {
   /**
    * Constructs a no op call for the initStorage(pay)void ABI method
    *
-   * Called after we're created and then funded, so we can create our large stakers ledger storageCaller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage costIf this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.
+   * Called after we're created and then funded, so we can create our large stakers ledger storage.  Caller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage cost. If this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.
    *
    * @param args Any args for the contract call
    * @param params Any additional parameters for the call
@@ -965,7 +965,7 @@ export abstract class StakingPoolCallFactory {
   /**
    * Constructs a no op call for the epochBalanceUpdate()void ABI method
    *
-   * Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.The validator is paid their percentage each epoch payout.Note: ANYONE can call this.
+   * Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.  The validator is paid their percentage each epoch payout.Note: ANYONE can call this.
    *
    * @param args Any args for the contract call
    * @param params Any additional parameters for the call
@@ -1027,7 +1027,7 @@ export abstract class StakingPoolCallFactory {
   /**
    * Constructs a no op call for the proxiedSetTokenPayoutRatio((uint64,uint64,uint64))(uint64[24],uint64) ABI method
    *
-   * proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts
+   * proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1.  We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts
    *
    * @param args Any args for the contract call
    * @param params Any additional parameters for the call
@@ -1176,7 +1176,7 @@ export class StakingPoolClient {
   /**
    * Calls the initStorage(pay)void ABI method.
    *
-   * Called after we're created and then funded, so we can create our large stakers ledger storageCaller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage costIf this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.
+   * Called after we're created and then funded, so we can create our large stakers ledger storage.  Caller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage cost. If this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -1232,7 +1232,7 @@ export class StakingPoolClient {
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
-   * @returns The result of the call: {StakedInfo}- The staked information for the given staker.
+   * @returns The result of the call: {StakedInfo} - The staked information for the given staker.
    */
   public getStakerInfo(args: MethodArgs<'getStakerInfo(address)(address,uint64,uint64,uint64,uint64)'>, params: AppClientCallCoreParams & CoreAppCallArgs = {}) {
     return this.call(StakingPoolCallFactory.getStakerInfo(args, params))
@@ -1267,7 +1267,7 @@ export class StakingPoolClient {
   /**
    * Calls the epochBalanceUpdate()void ABI method.
    *
-   * Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.The validator is paid their percentage each epoch payout.Note: ANYONE can call this.
+   * Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.  The validator is paid their percentage each epoch payout.Note: ANYONE can call this.
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -1317,7 +1317,7 @@ export class StakingPoolClient {
   /**
    * Calls the proxiedSetTokenPayoutRatio((uint64,uint64,uint64))(uint64[24],uint64) ABI method.
    *
-   * proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts
+   * proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1.  We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -1550,7 +1550,7 @@ export type StakingPoolComposer<TReturns extends [...any[]] = []> = {
   /**
    * Calls the initStorage(pay)void ABI method.
    *
-   * Called after we're created and then funded, so we can create our large stakers ledger storageCaller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage costIf this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.
+   * Called after we're created and then funded, so we can create our large stakers ledger storage.  Caller has to get MBR amounts from ValidatorRegistry to know how much to fund us to cover the box storage cost. If this is pool 1 AND the validator has specified a reward token, opt-in to that tokenso that the validator can seed the pool with future rewards of that token.
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -1627,7 +1627,7 @@ export type StakingPoolComposer<TReturns extends [...any[]] = []> = {
   /**
    * Calls the epochBalanceUpdate()void ABI method.
    *
-   * Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.The validator is paid their percentage each epoch payout.Note: ANYONE can call this.
+   * Updates the balance of stakers in the pool based on the received 'rewards' (current balance vs known staked balance)stakers outstanding balance is adjusted based on their % of stake and time in the current epoch - so that balancecompounds over time and staker can remove that amount at will.  The validator is paid their percentage each epoch payout.Note: ANYONE can call this.
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -1669,7 +1669,7 @@ export type StakingPoolComposer<TReturns extends [...any[]] = []> = {
   /**
    * Calls the proxiedSetTokenPayoutRatio((uint64,uint64,uint64))(uint64[24],uint64) ABI method.
    *
-   * proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts
+   * proxiedSetTokenPayoutRatio is meant to be called by pools != 1 - calling US, pool #1.  We need to verify that we are in fact being called by another of OUR pools (not us)and then we'll call the validator on their behalf to update the token payouts
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call

--- a/ui/src/contracts/ValidatorRegistryClient.ts
+++ b/ui/src/contracts/ValidatorRegistryClient.ts
@@ -382,7 +382,7 @@ export const APP_SPEC: AppSpec = {
           {
             "name": "validatorId",
             "type": "uint64",
-            "desc": "@return{PoolInfo[]}- array of poolsNot callable from other contracts because>1K return but can be called w/ simulate which bumps log returns"
+            "desc": "@return{PoolInfo[]} - array of poolsNot callable from other contracts because >1K return but can be called w/ simulate which bumps log returns"
           }
         ],
         "returns": {
@@ -465,7 +465,7 @@ export const APP_SPEC: AppSpec = {
           {
             "name": "validatorId",
             "type": "uint64",
-            "desc": "The id of the validator.@return{PoolTokenPayoutRatio}- The token payout ratio for the validator."
+            "desc": "The id of the validator. @return{PoolTokenPayoutRatio}- The token payout ratio for the validator."
           }
         ],
         "returns": {
@@ -725,7 +725,7 @@ export const APP_SPEC: AppSpec = {
           {
             "name": "saturatedBurnToFeeSink",
             "type": "uint64",
-            "desc": "if the pool was in saturated state, the amount sent back to the fee sink.seen as 'accounted for/pending spent')"
+            "desc": "if the pool was in saturated state, the amount sent back to the fee sink.  Seen as 'accounted for/pending spent')"
           }
         ],
         "returns": {
@@ -791,7 +791,7 @@ export const APP_SPEC: AppSpec = {
       },
       {
         "name": "movePoolToNode",
-        "desc": "Find the specified pool (in any node number) and move it to the specified node.The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]",
+        "desc": "Find the specified pool (in any node number) and move it to the specified node.  The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]",
         "args": [
           {
             "name": "validatorId",
@@ -813,7 +813,7 @@ export const APP_SPEC: AppSpec = {
       },
       {
         "name": "emptyTokenRewards",
-        "desc": "Sends the reward tokens held in pool 1 to specified receiver.This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim willNOT be sent as they must be held back for stakers to later claim.[ ONLY OWNER CAN CALL]",
+        "desc": "Sends the reward tokens held in pool 1 to specified receiver.  This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim will NOT be sent as they must be held back for stakers to later claim. [ ONLY OWNER CAN CALL]",
         "args": [
           {
             "name": "validatorId",
@@ -986,7 +986,7 @@ export type ValidatorRegistry = {
     & Record<'getPools(uint64)(uint64,uint16,uint64)[]' | 'getPools', {
       argsObj: {
         /**
-         * @return{PoolInfo[]}- array of poolsNot callable from other contracts because>1K return but can be called w/ simulate which bumps log returns
+         * @return{PoolInfo[]} - array of poolsNot callable from other contracts because >1K return but can be called w/ simulate which bumps log returns
          */
         validatorId: bigint | number
       }
@@ -1038,7 +1038,7 @@ export type ValidatorRegistry = {
     & Record<'getTokenPayoutRatio(uint64)(uint64[24],uint64)' | 'getTokenPayoutRatio', {
       argsObj: {
         /**
-         * The id of the validator.@return{PoolTokenPayoutRatio}- The token payout ratio for the validator.
+         * The id of the validator. @return{PoolTokenPayoutRatio}- The token payout ratio for the validator.
          */
         validatorId: bigint | number
       }
@@ -1223,7 +1223,7 @@ export type ValidatorRegistry = {
          */
         validatorCommission: bigint | number
         /**
-         * if the pool was in saturated state, the amount sent back to the fee sink.seen as 'accounted for/pending spent')
+         * if the pool was in saturated state, the amount sent back to the fee sink.  Seen as 'accounted for/pending spent')
          */
         saturatedBurnToFeeSink: bigint | number
       }
@@ -1897,7 +1897,7 @@ export abstract class ValidatorRegistryCallFactory {
   /**
    * Constructs a no op call for the movePoolToNode(uint64,uint64,uint64)void ABI method
    *
-   * Find the specified pool (in any node number) and move it to the specified node.The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]
+   * Find the specified pool (in any node number) and move it to the specified node.  The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]
    *
    * @param args Any args for the contract call
    * @param params Any additional parameters for the call
@@ -1913,7 +1913,7 @@ export abstract class ValidatorRegistryCallFactory {
   /**
    * Constructs a no op call for the emptyTokenRewards(uint64,address)uint64 ABI method
    *
-   * Sends the reward tokens held in pool 1 to specified receiver.This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim willNOT be sent as they must be held back for stakers to later claim.[ ONLY OWNER CAN CALL]
+   * Sends the reward tokens held in pool 1 to specified receiver.  This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim will NOT be sent as they must be held back for stakers to later claim. [ ONLY OWNER CAN CALL]
    *
    * @param args Any args for the contract call
    * @param params Any additional parameters for the call
@@ -2432,7 +2432,7 @@ export class ValidatorRegistryClient {
   /**
    * Calls the movePoolToNode(uint64,uint64,uint64)void ABI method.
    *
-   * Find the specified pool (in any node number) and move it to the specified node.The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]
+   * Find the specified pool (in any node number) and move it to the specified node.  The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -2445,7 +2445,7 @@ export class ValidatorRegistryClient {
   /**
    * Calls the emptyTokenRewards(uint64,address)uint64 ABI method.
    *
-   * Sends the reward tokens held in pool 1 to specified receiver.This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim willNOT be sent as they must be held back for stakers to later claim.[ ONLY OWNER CAN CALL]
+   * Sends the reward tokens held in pool 1 to specified receiver.  This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim will NOT be sent as they must be held back for stakers to later claim. [ ONLY OWNER CAN CALL]
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -3058,7 +3058,7 @@ export type ValidatorRegistryComposer<TReturns extends [...any[]] = []> = {
   /**
    * Calls the movePoolToNode(uint64,uint64,uint64)void ABI method.
    *
-   * Find the specified pool (in any node number) and move it to the specified node.The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]
+   * Find the specified pool (in any node number) and move it to the specified node.  The pool account is forced offline if moved so prior node will still run for 320 rounds butnew key goes online on new node soon after (320 rounds after it goes online)No-op if success, asserts if not found or can't move  (no space in target)[ ONLY OWNER OR MANAGER CAN CHANGE ]
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call
@@ -3069,7 +3069,7 @@ export type ValidatorRegistryComposer<TReturns extends [...any[]] = []> = {
   /**
    * Calls the emptyTokenRewards(uint64,address)uint64 ABI method.
    *
-   * Sends the reward tokens held in pool 1 to specified receiver.This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim willNOT be sent as they must be held back for stakers to later claim.[ ONLY OWNER CAN CALL]
+   * Sends the reward tokens held in pool 1 to specified receiver.  This is intended to be used by the owner when they want to get reward tokens 'back' which they sent tothe first pool (likely because validator is sunsetting.  Any tokens currently 'reserved' for stakers to claim will NOT be sent as they must be held back for stakers to later claim. [ ONLY OWNER CAN CALL]
    *
    * @param args The arguments for the contract call
    * @param params Any additional parameters for the call


### PR DESCRIPTION
## Summary
 - Clean up some typo and spacing issues in contract json files that I noticed.  I did a find and replace whenever i noticed one
 - I think I'm supposed to open PRs against `dev` branch, but let me know if I should be targeting another

## Testing Plan
 - Only copy changes, just review my suggestions.  