### PR TITLE
ci: add in default PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+### Description
+
+> _Please explain the changes you made here_
+
+### Checklist
+
+> _Please, make sure to comply with the checklist below before expecting review_
+
+- [ ] Code compiles correctly
+- [ ] Created tests which fail without the change (if possible)
+- [ ] All tests passing
+- [ ] Extended the README / documentation, if necessary


### PR DESCRIPTION
## Summary
 - Added in a default PR template to repo
 - I copied version from `use-wallet` repo (wasn't sure if was your organization template, but it works)