### PR TITLE
chore(ui): rename vite.config.ts -> vite.config.mjs

### DIFF
--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -27,7 +27,7 @@
     },
     "types": ["vitest/globals"]
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts", "vitest.setup.ts", "vite-env.d.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "vitest.setup.ts", "vite-env.d.ts"],
   "references": [
     {
       "path": "./tsconfig.node.json"

--- a/ui/tsconfig.node.json
+++ b/ui/tsconfig.node.json
@@ -7,5 +7,5 @@
     "resolveJsonModule": true,
     "types": ["node"]
   },
-  "include": ["vite.config.ts", "playwright.config.ts"]
+  "include": ["playwright.config.ts"]
 }

--- a/ui/vite.config.mjs
+++ b/ui/vite.config.mjs
@@ -3,14 +3,14 @@ import { TanStackRouterVite } from '@tanstack/router-vite-plugin'
 import react from '@vitejs/plugin-react'
 import fs from 'fs'
 import path from 'path'
-import { defineConfig, Plugin } from 'vite'
+import { defineConfig } from 'vite'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import { version } from './package.json'
 
 /**
  * This plugin replaces the `__APP_VERSION__` placeholder in the `public/version.json` file
  */
-const replaceVersionPlugin = (): Plugin => {
+const replaceVersionPlugin = () => {
   return {
     name: 'replace-version-in-json',
     apply: 'build',


### PR DESCRIPTION
When TypeScript is upgraded to the latest version (v5.5.2), UI production builds fail. The error is not particularly helpful to diagnose the issue, but it is related to the transpilation of `vite.config.ts`.

```
$ pnpm run build

> reti-ui@0.9.5 build /Users/drichar/Projects/TxnLab/reti/ui
> tsc && vite build

error TS6305: Output file '/Users/drichar/Projects/TxnLab/reti/ui/vite.config.d.ts' has not been built from source file '/Users/drichar/Projects/TxnLab/reti/ui/vite.config.ts'.
  The file is in the program because:
    Matched by include pattern 'vite.config.ts' in '/Users/drichar/Projects/TxnLab/reti/ui/tsconfig.json'

  tsconfig.json:30:46
    30   "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts", "vitest.setup.ts", "vite-env.d.ts"],
                                                    ~~~~~~~~~~~~~~~~
    File is matched by include pattern specified here.
```

There was only one type being used in the config file, so I removed the type and renamed the file to `vite.config.mjs`, then removed it from the tsconfig.json `include` array. This resolved the issue.