### PR TITLE
chore(ui): update deprecated algokit methods

### DIFF
--- a/ui/src/api/algod.ts
+++ b/ui/src/api/algod.ts
@@ -1,5 +1,5 @@
-import * as algokit from '@algorandfoundation/algokit-utils'
 import { AlgoAmount } from '@algorandfoundation/algokit-utils/types/amount'
+import { ClientManager } from '@algorandfoundation/algokit-utils/types/client-manager'
 import {
   AccountAssetInformation,
   AccountBalance,
@@ -15,7 +15,7 @@ import {
 import { getAlgodConfigFromViteEnvironment } from '@/utils/network/getAlgoClientConfigs'
 
 const algodConfig = getAlgodConfigFromViteEnvironment()
-const algodClient = algokit.getAlgoClient({
+const algodClient = ClientManager.getAlgodClient({
   server: algodConfig.server,
   port: algodConfig.port,
   token: algodConfig.token,

--- a/ui/src/api/clients.ts
+++ b/ui/src/api/clients.ts
@@ -1,5 +1,5 @@
-import * as algokit from '@algorandfoundation/algokit-utils'
 import { TransactionSignerAccount } from '@algorandfoundation/algokit-utils/types/account'
+import { ClientManager } from '@algorandfoundation/algokit-utils/types/client-manager'
 import algosdk from 'algosdk'
 import { FEE_SINK } from '@/constants/accounts'
 import { StakingPoolClient } from '@/contracts/StakingPoolClient'
@@ -10,7 +10,7 @@ import { getAlgodConfigFromViteEnvironment } from '@/utils/network/getAlgoClient
 import { ParamsCache } from '@/utils/paramsCache'
 
 const algodConfig = getAlgodConfigFromViteEnvironment()
-const algodClient = algokit.getAlgoClient({
+const algodClient = ClientManager.getAlgodClient({
   server: algodConfig.server,
   port: algodConfig.port,
   token: algodConfig.token,

--- a/ui/src/api/contracts.ts
+++ b/ui/src/api/contracts.ts
@@ -1,6 +1,7 @@
 import * as algokit from '@algorandfoundation/algokit-utils'
 import { TransactionSignerAccount } from '@algorandfoundation/algokit-utils/types/account'
 import { AlgoAmount } from '@algorandfoundation/algokit-utils/types/amount'
+import { ClientManager } from '@algorandfoundation/algokit-utils/types/client-manager'
 import { QueryClient } from '@tanstack/react-query'
 import algosdk from 'algosdk'
 import { fetchAccountBalance, fetchAsset, isOptedInToAsset } from '@/api/algod'
@@ -49,7 +50,7 @@ import { ParamsCache } from '@/utils/paramsCache'
 import { encodeCallParams } from '@/utils/tests/abi'
 
 const algodConfig = getAlgodConfigFromViteEnvironment()
-const algodClient = algokit.getAlgoClient({
+const algodClient = ClientManager.getAlgodClient({
   server: algodConfig.server,
   port: algodConfig.port,
   token: algodConfig.token,

--- a/ui/src/utils/balanceChecker.ts
+++ b/ui/src/utils/balanceChecker.ts
@@ -1,4 +1,4 @@
-import * as algokit from '@algorandfoundation/algokit-utils'
+import { ClientManager } from '@algorandfoundation/algokit-utils/types/client-manager'
 import algosdk from 'algosdk'
 import { formatAlgoAmount } from '@/utils/format'
 import { getAlgodConfigFromViteEnvironment } from '@/utils/network/getAlgoClientConfigs'
@@ -30,7 +30,7 @@ export class BalanceChecker {
     this.address = address
 
     const algodConfig = getAlgodConfigFromViteEnvironment()
-    this.algodClient = algokit.getAlgoClient({
+    this.algodClient = ClientManager.getAlgodClient({
       server: algodConfig.server,
       port: algodConfig.port,
       token: algodConfig.token,

--- a/ui/src/utils/development.tsx
+++ b/ui/src/utils/development.tsx
@@ -1,6 +1,8 @@
 import * as algokit from '@algorandfoundation/algokit-utils'
+import { AlgorandClient } from '@algorandfoundation/algokit-utils'
 import { getTestAccount } from '@algorandfoundation/algokit-utils/testing'
 import { AlgoAmount } from '@algorandfoundation/algokit-utils/types/amount'
+import { ClientManager } from '@algorandfoundation/algokit-utils/types/client-manager'
 import { QueryClient } from '@tanstack/react-query'
 import { useRouter } from '@tanstack/react-router'
 import algosdk from 'algosdk'
@@ -17,11 +19,20 @@ import { getAlgodConfigFromViteEnvironment } from '@/utils/network/getAlgoClient
 import { ParamsCache } from '@/utils/paramsCache'
 
 const algodConfig = getAlgodConfigFromViteEnvironment()
-const algodClient = algokit.getAlgoClient({
+
+const algodClient = ClientManager.getAlgodClient({
   server: algodConfig.server,
   port: algodConfig.port,
   token: algodConfig.token,
 })
+
+const kmdClient = ClientManager.getKmdClient({
+  server: algodConfig.server,
+  port: algodConfig.port,
+  token: algodConfig.token,
+})
+
+const algorandClient = AlgorandClient.fromClients({ algod: algodClient, kmd: kmdClient })
 
 async function wait(ms: number) {
   return new Promise((resolve) => {
@@ -48,16 +59,9 @@ export async function incrementRoundNumberBy(rounds: number) {
 
   // console.log(`Increment round number start: ${result.startRound}`)
 
-  const kmdClient = algokit.getAlgoKmdClient({
-    server: algodConfig.server,
-    port: algodConfig.port,
-    token: algodConfig.token,
-  })
-
   const testAccount = await getTestAccount(
     { initialFunds: AlgoAmount.Algos(10), suppressLog: true },
-    algodClient,
-    kmdClient,
+    algorandClient,
   )
 
   let txnId = ''

--- a/ui/src/utils/paramsCache.spec.ts
+++ b/ui/src/utils/paramsCache.spec.ts
@@ -1,4 +1,4 @@
-import * as algokit from '@algorandfoundation/algokit-utils'
+import { ClientManager } from '@algorandfoundation/algokit-utils/types/client-manager'
 import algosdk from 'algosdk'
 import { ParamsCache } from '@/utils/paramsCache'
 
@@ -14,12 +14,14 @@ const mockParams: algosdk.SuggestedParams = {
 const mockGetTransactionParams = vi.fn().mockResolvedValue(mockParams)
 
 // Mock algokit-utils
-vi.mock('@algorandfoundation/algokit-utils', () => ({
-  getAlgoClient: vi.fn(() => ({
-    getTransactionParams: vi.fn(() => ({
-      do: mockGetTransactionParams,
+vi.mock('@algorandfoundation/algokit-utils/types/client-manager', () => ({
+  ClientManager: {
+    getAlgodClient: vi.fn(() => ({
+      getTransactionParams: vi.fn(() => ({
+        do: mockGetTransactionParams,
+      })),
     })),
-  })),
+  },
 }))
 
 // Mock getAlgodConfigFromViteEnvironment
@@ -39,18 +41,18 @@ beforeEach(() => {
 describe('ParamsCache', () => {
   it('should fetch and cache transaction parameters', async () => {
     const params = await ParamsCache.getSuggestedParams()
-    expect(algokit.getAlgoClient).toHaveBeenCalledTimes(1) // First call
+    expect(ClientManager.getAlgodClient).toHaveBeenCalledTimes(1) // First call
     expect(params).toEqual(mockParams)
 
     // Simulate another call within 5 minutes
     const cachedParams = await ParamsCache.getSuggestedParams()
-    expect(algokit.getAlgoClient).toHaveBeenCalledTimes(1) // No second call (cached)
+    expect(ClientManager.getAlgodClient).toHaveBeenCalledTimes(1) // No second call (cached)
     expect(cachedParams).toEqual(params)
   })
 
   it('should refresh cached parameters after expiration', async () => {
     const initialParams = await ParamsCache.getSuggestedParams()
-    expect(algokit.getAlgoClient).toHaveBeenCalledTimes(1) // First call
+    expect(ClientManager.getAlgodClient).toHaveBeenCalledTimes(1) // First call
     expect(initialParams).toEqual(mockParams)
 
     // Mock Date.now to simulate cache expiration (5 minutes later)

--- a/ui/src/utils/paramsCache.ts
+++ b/ui/src/utils/paramsCache.ts
@@ -1,4 +1,4 @@
-import * as algokit from '@algorandfoundation/algokit-utils'
+import { ClientManager } from '@algorandfoundation/algokit-utils/types/client-manager'
 import algosdk from 'algosdk'
 import { getAlgodConfigFromViteEnvironment } from '@/utils/network/getAlgoClientConfigs'
 
@@ -23,7 +23,7 @@ export class ParamsCache {
 
   private constructor() {
     const algodConfig = getAlgodConfigFromViteEnvironment()
-    this.client = algokit.getAlgoClient({
+    this.client = ClientManager.getAlgodClient({
       server: algodConfig.server,
       port: algodConfig.port,
       token: algodConfig.token,


### PR DESCRIPTION
Upgrading to the latest version of `@algorandfoundation/algokit-utils` introduces deprecation notices for methods that were previously exposed using a namespace import of the package:

```ts
import * as algokit from '@algorandfoundation/algokit-utils'

// example
const algodClient = algokit.getAlgodClient({ ... })
```

These clients are now created using a `ClientManager`. Using the above example:

```ts
import { ClientManager } from '@algorandfoundation/algokit-utils/types/client-manager'

const algodClient = ClientManager.getAlgodClient({ ... })
```

The `getAlgodClient` and `getKmdClient` methods have been updated according to the notices' instructions.

Also, the `getTestAccount` method in https://github.com/TxnLab/reti/blob/ea9d362d1e0ea0c864da816d69476283304b52e6/ui/src/utils/development.tsx now accepts an `AlgorandClient` instance rather than passing the Algod client and KMD client directly:

```ts
const algod = ClientManager.getAlgodClient({ ... })
const kmd = ClientManager.getKmdClient({ ... })

const algorandClient = AlgorandClient.fromClients({ algod, kmd })

const params: GetTestAccountParams = { ... }
const testAccount = await getTestAccount(params, algorandClient)
```