### PR TITLE
fix(ui): use configured outDir for replace version plugin

### DIFF
--- a/ui/vite.config.mjs
+++ b/ui/vite.config.mjs
@@ -11,15 +11,19 @@ import { version } from './package.json'
  * This plugin replaces the `__APP_VERSION__` placeholder in the `public/version.json` file
  */
 const replaceVersionPlugin = () => {
+  let outDir
   return {
     name: 'replace-version-in-json',
     apply: 'build',
     enforce: 'pre',
+    configResolved(config) {
+      outDir = config.build.outDir
+    },
     generateBundle() {
       const filePath = path.resolve(__dirname, 'public/version.json')
       const content = fs.readFileSync(filePath, 'utf-8')
       const updatedContent = content.replace('__APP_VERSION__', version)
-      const newFilePath = path.resolve(__dirname, 'dist/version.json')
+      const newFilePath = path.resolve(outDir, 'version.json')
       fs.writeFileSync(newFilePath, updatedContent, 'utf-8')
     },
   }


### PR DESCRIPTION
## Description

This PR enhances the `replaceVersionPlugin` in the Vite configuration by using the configured output directory when writing the `version.json` file. The plugin now captures the `outDir` from the Vite config and uses this value when determining the path for the new `version.json` file.

This change allows the build process to work correctly when a custom output directory is specified, resolving an issue where the plugin would fail to find the `version.json` file in the expected location.

## Details
- Add `configResolved` hook to capture `outDir` from Vite config
- Replace hardcoded 'dist' with `outDir` when writing `version.json`
- Ensure `version.json` is created in the correct output directory during build