### PR TITLE
chore(ui): pin pnpm version to 9.15.9 across environments

### DIFF
--- a/.github/workflows/ci-ui.yaml
+++ b/.github/workflows/ci-ui.yaml
@@ -2,13 +2,13 @@ name: CI Workflow (UI)
 
 on:
   push:
-    branches: [ dev, main ]
+    branches: [dev, main]
     paths:
       - 'ui/**'
       - '.github/workflows/ci-ui.yaml'
 
   pull_request:
-    branches: [ dev, main ]
+    branches: [dev, main]
     paths:
       - 'ui/**'
       - '.github/workflows/ci-ui.yaml'
@@ -41,7 +41,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 9.2.0
+          version: 9.15.9
           run_install: false
 
       - name: Get pnpm store directory

--- a/renovate.json
+++ b/renovate.json
@@ -32,7 +32,8 @@
       "matchPackageNames": ["!vitest", "!@vitest/**"],
       "assignees": ["drichar"],
       "semanticCommitScope": "ui",
-      "rangeStrategy": "pin"
+      "rangeStrategy": "pin",
+      "ignoreDeps": ["packageManager"]
     },
     {
       "groupName": "Vitest",

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,6 +3,7 @@
   "version": "1.3.6",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@9.15.9",
   "engines": {
     "node": "20"
   },


### PR DESCRIPTION
## Description

This PR ensures consistent pnpm version usage across all deployment and development environments by pinning to `pnpm@9.15.9`.

## Details
- Added `packageManager` field to UI `package.json` specifying `pnpm@9.15.9` for Corepack compatibility
- Updated CI workflow to use `pnpm@9.15.9` instead of `9.2.0` for version consistency
- Configured Renovate to ignore `packageManager` field updates to prevent automatic pnpm version bumps
- Ensures Vercel deployments use the intended pnpm version via Corepack integration